### PR TITLE
fix: size prover manage TUI columns to their content

### DIFF
--- a/crates/quil-client/src/commands/node/prover/epoch.rs
+++ b/crates/quil-client/src/commands/node/prover/epoch.rs
@@ -40,16 +40,16 @@ impl EffectiveStatus {
     /// Display label (`effectiveStatus.String()`).
     pub fn label(self) -> &'static str {
         match self {
-            EffectiveStatus::Joining => "Joining",
-            EffectiveStatus::Active => "Active",
-            EffectiveStatus::Paused => "Paused",
-            EffectiveStatus::Leaving => "Leaving",
-            EffectiveStatus::ExpiredJoining => "ExpiredJoin",
-            EffectiveStatus::ExpiredLeaving => "ExpiredLeave",
-            EffectiveStatus::ExpiredEpoch => "Re-confirm!",
-            EffectiveStatus::Rejected => "Rejected",
-            EffectiveStatus::Kicked => "Kicked",
-            EffectiveStatus::Unknown => "Unknown",
+            EffectiveStatus::Joining => "joining",
+            EffectiveStatus::Active => "active",
+            EffectiveStatus::Paused => "paused",
+            EffectiveStatus::Leaving => "leaving",
+            EffectiveStatus::ExpiredJoining => "expiredJoin",
+            EffectiveStatus::ExpiredLeaving => "expiredLeave",
+            EffectiveStatus::ExpiredEpoch => "re-confirm!",
+            EffectiveStatus::Rejected => "rejected",
+            EffectiveStatus::Kicked => "kicked",
+            EffectiveStatus::Unknown => "unknown",
         }
     }
 

--- a/crates/quil-client/src/commands/node/prover/manage/model.rs
+++ b/crates/quil-client/src/commands/node/prover/manage/model.rs
@@ -51,14 +51,34 @@ pub fn avail_filter_col_kind(col: usize) -> FilterColKind {
     }
 }
 
-// Column widths (mirror the Go consts).
+/// How the two tables size their columns. Toggled at runtime with `w`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ColumnSizing {
+    /// Measure every column against the rows on screen: a column is as wide
+    /// as its own content needs and no wider.
+    #[default]
+    Dynamic,
+    /// The historical layout — a fixed width per column, sized for that
+    /// column's worst case rather than for what the table is showing.
+    Fixed,
+}
+
+// ── Column widths (`ColumnSizing::Fixed`) ────────────────────────────────
+//
+// Mirrors the Go consts. Shards and the reward columns are minimums rather
+// than fixed widths: their content has no upper bound and `{:>w$}` doesn't
+// clip, so an over-wide cell would shift every column after it.
+
 pub const SELECT_WIDTH: usize = 6;
 pub const FILTER_WIDTH: usize = 70;
 pub const PROVERS_WIDTH: usize = 7;
 pub const RING_WIDTH: usize = 5;
 pub const SIZE_WIDTH: usize = 10;
 pub const SHARDS_WIDTH: usize = 7;
+/// Available panel: cells carry a ` Q/f` suffix, so they need the extra room.
 pub const REWARD_WIDTH: usize = 20;
+/// Allocations panel: bare `~<value>` cells.
+pub const ALLOC_REWARD_WIDTH: usize = 14;
 pub const WORKER_WIDTH: usize = 7;
 pub const STATUS_WIDTH: usize = 12;
 pub const MODE_WIDTH: usize = 4;
@@ -71,7 +91,7 @@ pub const ALLOC_FIXED_WIDTH: usize = SELECT_WIDTH
     + RING_WIDTH
     + SIZE_WIDTH
     + SHARDS_WIDTH
-    + REWARD_WIDTH
+    + ALLOC_REWARD_WIDTH
     + WORKER_WIDTH
     + STATUS_WIDTH
     + MODE_WIDTH
@@ -83,6 +103,10 @@ pub const ALLOC_FIXED_WIDTH: usize = SELECT_WIDTH
 // 6 spaces between 7 columns, 2 external borders, 2-char sort indicator.
 pub const AVAIL_FIXED_WIDTH: usize =
     SELECT_WIDTH + PROVERS_WIDTH + RING_WIDTH + SIZE_WIDTH + SHARDS_WIDTH + REWARD_WIDTH + 6 + 2 + 2;
+
+/// Floor for the Filter column in either layout. Filter is what gives way
+/// when the pane cannot hold the table, being the only column whose content
+/// is already truncated for display.
 pub const MIN_FILTER_WIDTH: usize = 12;
 
 pub const ACTION_FRAME_DELAY: u64 = 360;
@@ -116,6 +140,19 @@ pub struct AllocationRow {
     pub epoch: u64,
     #[allow(dead_code)]
     pub last_active_frame: u64,
+}
+
+impl AllocationRow {
+    /// The Mode cell — `m` when the row's worker is managed by hand, `a` when
+    /// the node assigns it. Cell values are lower-case; headers carry the
+    /// capital.
+    pub fn mode(&self) -> &'static str {
+        if self.manually_managed {
+            "m"
+        } else {
+            "a"
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -265,6 +302,7 @@ pub struct Model {
     pub action_in_flight: bool,
     pub show_help: bool,
     pub color_coding: bool,
+    pub column_sizing: ColumnSizing,
     pub spinner_frame: usize,
 
     // Load / staleness tracking.
@@ -469,7 +507,7 @@ impl Model {
                         filter_key: format!("worker:{}", w.core_id),
                         filter_hex: String::new(),
                         status: 0,
-                        status_name: "Idle".to_string(),
+                        status_name: "idle".to_string(),
                         ring: 0,
                         active_provers: 0,
                         shard_size: BigInt::from(0),
@@ -894,13 +932,7 @@ pub fn alloc_row_text_val(row: &AllocationRow, col: usize) -> String {
     match col {
         1 => row.filter_hex.clone(),
         8 => row.status_name.clone(),
-        9 => {
-            if row.manually_managed {
-                "M".to_string()
-            } else {
-                "A".to_string()
-            }
-        }
+        9 => row.mode().to_string(),
         _ => String::new(),
     }
 }
@@ -959,11 +991,11 @@ fn action_hints(
     if let Some(w) = alloc_confirm_window(t, el) {
         return match w.state(ef, el) {
             WindowState::Open => (
-                "Reject | Confirm now".to_string(),
+                "reject | confirm now".to_string(),
                 format!("thru f{}", w.end_frame),
             ),
             WindowState::Pending => (
-                format!("Reject | Confirm@f{}", w.start_frame),
+                format!("reject | confirm@f{}", w.start_frame),
                 format!("epoch {}", w.confirm_epoch),
             ),
             WindowState::Missed => ("window missed".to_string(), "expired".to_string()),
@@ -976,9 +1008,9 @@ fn action_hints(
             } else {
                 String::new()
             };
-            ("Pause | Leave".to_string(), default)
+            ("pause | leave".to_string(), default)
         }
-        EffectiveStatus::Paused => ("Resume | Leave".to_string(), String::new()),
+        EffectiveStatus::Paused => ("resume | leave".to_string(), String::new()),
         EffectiveStatus::Joining => {
             if a.join_confirm_frame_number > 0 {
                 let act_e = epoch_for_frame(a.join_confirm_frame_number, el) + 1;
@@ -996,7 +1028,7 @@ fn action_hints(
             }
         }
         EffectiveStatus::ExpiredEpoch => {
-            ("Confirm now (renew)".to_string(), "re-confirm!".to_string())
+            ("confirm now (renew)".to_string(), "re-confirm!".to_string())
         }
         _ => (String::new(), String::new()),
     }

--- a/crates/quil-client/src/commands/node/prover/manage/update.rs
+++ b/crates/quil-client/src/commands/node/prover/manage/update.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::model::{
-    AwaitFilterEntry, ColumnFilter, FilterColKind, Model, PanelFocus, PendingAction,
+    AwaitFilterEntry, ColumnFilter, ColumnSizing, FilterColKind, Model, PanelFocus, PendingAction,
     ACTION_FRAME_DELAY,
 };
 use super::msg::Msg;
@@ -409,6 +409,13 @@ fn handle_normal_key(m: &mut Model, ev: KeyEvent) -> Vec<Cmd> {
         }
         KeyCode::Char('C') => {
             m.color_coding = !m.color_coding;
+            return vec![];
+        }
+        KeyCode::Char('w') => {
+            m.column_sizing = match m.column_sizing {
+                ColumnSizing::Dynamic => ColumnSizing::Fixed,
+                ColumnSizing::Fixed => ColumnSizing::Dynamic,
+            };
             return vec![];
         }
         KeyCode::Tab => {

--- a/crates/quil-client/src/commands/node/prover/manage/view.rs
+++ b/crates/quil-client/src/commands/node/prover/manage/view.rs
@@ -10,7 +10,7 @@ use ratatui::{
     Frame,
 };
 
-use super::super::{format_quil_daily, format_quil_reward, format_storage};
+use super::super::{format_quil_daily, format_quil_reward};
 use super::model::*;
 use super::util::{center_trunc, clamp_offset};
 
@@ -46,7 +46,7 @@ fn status_color(name: &str) -> Color {
 }
 
 fn mode_color(mode: &str) -> Color {
-    if mode == "M" {
+    if mode == "m" {
         Color::Rgb(0xff, 0x88, 0x00)
     } else {
         Color::Rgb(0x00, 0xff, 0x00)
@@ -64,6 +64,54 @@ fn fmt_reward(v: &BigInt) -> String {
 
 fn fmt_mb(v: &BigInt) -> String {
     format!("{:.1}", bigint_to_f64(v) / (1024.0 * 1024.0))
+}
+
+/// A column header as printed: sort indicator, name, active-filter marker.
+/// Sizing and rendering share it, so a column is never measured against a
+/// different string than it draws.
+///
+/// `compact` underscores the spaces inside a name. Measured columns sit one
+/// space apart, which leaves `Next Action Default Action` with no way to see
+/// where one header ends; `Next_Action Default_Action` reads unambiguously.
+/// The fixed layout has slack between columns and keeps the spaces.
+fn header_text(
+    name: &str,
+    idx: usize,
+    sort_col: i32,
+    asc: bool,
+    filtered: bool,
+    compact: bool,
+) -> String {
+    let mut s = if compact {
+        name.replace(' ', "_")
+    } else {
+        name.to_string()
+    };
+    if filtered {
+        s.push('*');
+    }
+    if sort_col == idx as i32 {
+        s.insert_str(0, if asc { "^|" } else { "v|" });
+    }
+    s
+}
+
+/// Width a `ColumnSizing::Fixed` column needs: its constant, which doubles as
+/// the minimum, widened to the longest cell. `{:>w$}` doesn't clip, so a cell
+/// wider than its column shifts every column after it to the right; columns
+/// whose content has no fixed upper bound have to be measured even here.
+fn fit(base: usize, cells: impl Iterator<Item = usize>) -> usize {
+    cells.max().unwrap_or(0).max(base)
+}
+
+/// Width of one column: its printed header, widened to its widest cell.
+///
+/// Every column is measured, in both directions. `{:>w$}` doesn't clip, so a
+/// cell wider than its column shifts every column after it out of alignment;
+/// a column wider than its content spends the difference on blanks and pushes
+/// the columns to its right off the pane. Measuring is the fix for both.
+fn col_width(header: &str, cells: impl Iterator<Item = usize>) -> usize {
+    cells.max().unwrap_or(0).max(header.len())
 }
 
 // ── Entry ────────────────────────────────────────────────────────────────
@@ -221,8 +269,107 @@ fn avail_title(m: &Model, sorted: &[ShardRow]) -> Line<'static> {
 
 // ── Allocations panel ────────────────────────────────────────────────────
 
-fn alloc_col_widths(m: &Model, content_width: usize) -> (Vec<usize>, usize) {
-    let mut fw = content_width.saturating_sub(ALLOC_FIXED_WIDTH);
+/// The printed text of one allocations cell. Sizing and rendering both go
+/// through here. `fw` is the Filter column's width, which is a budget rather
+/// than a measurement — pass 0 when measuring the other columns.
+fn alloc_cell(m: &Model, a: &AllocationRow, col: usize, fw: usize) -> String {
+    match col {
+        0 => alloc_marker(m, a).to_string(),
+        1 => center_trunc(&a.filter_hex, fw),
+        2 => a.active_provers.to_string(),
+        3 => a.ring.to_string(),
+        4 => fmt_mb(&a.shard_size),
+        5 => a.data_shards.to_string(),
+        6 => fmt_reward(&a.estimated_reward),
+        7 => a.worker_id.to_string(),
+        8 => a.status_name.clone(),
+        9 => a.mode().to_string(),
+        10 => a.next_action.clone(),
+        _ => a.default_action.clone(),
+    }
+}
+
+fn alloc_marker(m: &Model, a: &AllocationRow) -> &'static str {
+    if m.alloc_selected.contains(&a.filter_key) {
+        "[x]"
+    } else {
+        "[ ]"
+    }
+}
+
+fn alloc_header(m: &Model, idx: usize) -> String {
+    header_text(
+        ALLOC_COL_NAMES[idx],
+        idx,
+        m.alloc_sort_col,
+        m.alloc_sort_asc,
+        m.alloc_col_filters
+            .get(&idx)
+            .is_some_and(|cf| cf.is_active()),
+        m.column_sizing == ColumnSizing::Dynamic,
+    )
+}
+
+fn alloc_col_widths(
+    m: &Model,
+    content_width: usize,
+    sorted: &[AllocationRow],
+) -> (Vec<usize>, usize) {
+    match m.column_sizing {
+        ColumnSizing::Dynamic => alloc_widths_measured(m, content_width, sorted),
+        ColumnSizing::Fixed => alloc_widths_fixed(m, content_width, sorted),
+    }
+}
+
+/// Every column takes its header or its widest cell, whichever is longer, one
+/// space apart — nothing reserves room for a value it isn't showing.
+/// Remeasured each frame, so the layout tracks the data.
+///
+/// Filter is sized last, from whatever the pane has left: it is the only
+/// column already truncated for display, so it is both the one that can grow
+/// usefully and the one that can give way without losing a value outright.
+fn alloc_widths_measured(
+    m: &Model,
+    content_width: usize,
+    sorted: &[AllocationRow],
+) -> (Vec<usize>, usize) {
+    let n = ALLOC_COL_NAMES.len();
+    let mut widths: Vec<usize> = (0..n)
+        .map(|c| {
+            col_width(
+                &alloc_header(m, c),
+                sorted.iter().map(|a| alloc_cell(m, a, c, 0).len()),
+            )
+        })
+        .collect();
+
+    let cap = filter_cap(
+        &alloc_header(m, 1),
+        sorted.iter().map(|a| a.filter_hex.len()),
+    );
+    let fw = filter_width(content_width, &widths, n, cap);
+    widths[1] = fw;
+    (widths, fw)
+}
+
+/// The historical layout: a constant per column, with Shards and Reward grown
+/// to their content so an over-wide cell can't shift the row.
+fn alloc_widths_fixed(
+    m: &Model,
+    content_width: usize,
+    sorted: &[AllocationRow],
+) -> (Vec<usize>, usize) {
+    let shards_w = fit(
+        SHARDS_WIDTH,
+        sorted.iter().map(|a| alloc_cell(m, a, 5, 0).len()),
+    );
+    let reward_w = fit(
+        ALLOC_REWARD_WIDTH,
+        sorted.iter().map(|a| alloc_cell(m, a, 6, 0).len()),
+    );
+    // Whatever the wide columns took comes out of the flexible Filter column.
+    let grown = (shards_w - SHARDS_WIDTH) + (reward_w - ALLOC_REWARD_WIDTH);
+    let mut fw = content_width.saturating_sub(ALLOC_FIXED_WIDTH + grown);
     for &col in &ALLOC_FILTERABLE_COLS {
         if col == 1 {
             continue;
@@ -239,8 +386,8 @@ fn alloc_col_widths(m: &Model, content_width: usize) -> (Vec<usize>, usize) {
         PROVERS_WIDTH,
         RING_WIDTH,
         SIZE_WIDTH,
-        SHARDS_WIDTH,
-        REWARD_WIDTH,
+        shards_w,
+        reward_w,
         WORKER_WIDTH,
         STATUS_WIDTH,
         MODE_WIDTH,
@@ -261,6 +408,29 @@ fn alloc_col_widths(m: &Model, content_width: usize) -> (Vec<usize>, usize) {
     (widths, fw)
 }
 
+/// How wide the Filter column can usefully get: the longest hex in the table,
+/// past which the extra columns would be padding. Its header is the floor, so
+/// the column is legible even when every row's filter is empty.
+fn filter_cap(header: &str, hexes: impl Iterator<Item = usize>) -> usize {
+    col_width(header, hexes).max(MIN_FILTER_WIDTH)
+}
+
+/// Filter takes what the pane has left after the other columns, the `n - 1`
+/// separators and the 2 borders, bounded by `cap` and `MIN_FILTER_WIDTH`.
+/// Below the floor the row is clipped rather than shrunk further — 12 columns
+/// is the least that leaves a recognisable hex.
+fn filter_width(content_width: usize, widths: &[usize], n: usize, cap: usize) -> usize {
+    let others: usize = widths
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != 1)
+        .map(|(_, w)| *w)
+        .sum();
+    content_width
+        .saturating_sub(others + (n - 1) + 2)
+        .clamp(MIN_FILTER_WIDTH, cap)
+}
+
 fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Vec<Line<'static>> {
     let content_width = area.width as usize;
     let height = area.height as usize;
@@ -270,22 +440,13 @@ fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Ve
         }
         return vec![Line::from("  No allocations")];
     }
-    let (widths, fw) = alloc_col_widths(m, content_width);
+    let (widths, fw) = alloc_col_widths(m, content_width, sorted);
     let filter_hi = m.active_filter_col_idx();
 
     // Header row.
     let mut hdr_spans: Vec<Span> = Vec::new();
-    for (i, name) in ALLOC_COL_NAMES.iter().enumerate() {
-        let w = widths[i];
-        let mut disp = name.to_string();
-        if m.alloc_col_filters.get(&i).is_some_and(|cf| cf.is_active()) {
-            disp.push('*');
-        }
-        if m.alloc_sort_col == i as i32 {
-            let ind = if m.alloc_sort_asc { "^|" } else { "v|" };
-            disp = format!("{ind}{disp}");
-        }
-        let cell = format!("{:>w$}", disp, w = w);
+    for i in 0..ALLOC_COL_NAMES.len() {
+        let cell = format!("{:>w$}", alloc_header(m, i), w = widths[i]);
         let style = if m.sort_mode && m.focus.is_alloc() && m.sort_highlight_col == i {
             Style::new().bg(PRIMARY).fg(TEXT).add_modifier(Modifier::BOLD)
         } else if m.alloc_filter_mode
@@ -310,29 +471,11 @@ fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Ve
 
     for i in m.alloc_offset..end {
         let a = &sorted[i];
-        let mode_str = if a.manually_managed { "M" } else { "A" };
-        let marker = if m.alloc_selected.contains(&a.filter_key) {
-            "[x]"
-        } else {
-            "[ ]"
-        };
-        let worker_str = a.worker_id.to_string();
         let selected = i == m.alloc_cursor && m.focus.is_alloc();
 
-        let cells = [
-            format!("{:>w$}", marker, w = widths[0]),
-            format!("{:>w$}", center_trunc(&a.filter_hex, fw), w = widths[1]),
-            format!("{:>w$}", a.active_provers, w = widths[2]),
-            format!("{:>w$}", a.ring, w = widths[3]),
-            format!("{:>w$}", fmt_mb(&a.shard_size), w = widths[4]),
-            format!("{:>w$}", a.data_shards, w = widths[5]),
-            format!("{:>w$}", fmt_reward(&a.estimated_reward), w = widths[6]),
-            format!("{:>w$}", worker_str, w = widths[7]),
-            format!("{:>w$}", a.status_name, w = widths[8]),
-            format!("{:>w$}", mode_str, w = widths[9]),
-            format!("{:>w$}", a.next_action, w = widths[10]),
-            format!("{:>w$}", a.default_action, w = widths[11]),
-        ];
+        let cells: Vec<String> = (0..widths.len())
+            .map(|c| format!("{:>w$}", alloc_cell(m, a, c, fw), w = widths[c]))
+            .collect();
 
         if selected {
             let joined = cells.join(" ");
@@ -353,7 +496,7 @@ fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Ve
                         Span::styled(cell.clone(), Style::new().fg(status_color(&a.status_name)))
                     }
                     9 if m.color_coding => {
-                        Span::styled(cell.clone(), Style::new().fg(mode_color(mode_str)))
+                        Span::styled(cell.clone(), Style::new().fg(mode_color(a.mode())))
                     }
                     _ => Span::raw(cell.clone()),
                 };
@@ -367,8 +510,91 @@ fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Ve
 
 // ── Available panel ──────────────────────────────────────────────────────
 
-fn avail_col_widths(m: &Model, content_width: usize) -> (Vec<usize>, usize) {
-    let mut fw = content_width.saturating_sub(AVAIL_FIXED_WIDTH);
+/// The printed text of one available-shards cell.
+///
+/// Every row prints the same way. The cursor row used to render size and
+/// reward differently from the rest — megabytes against an adaptive unit, a
+/// bare reward against one suffixed ` Q/f` — so moving the cursor changed the
+/// value under it, and the unsuffixed variants disagreed with the `Size [MB]`
+/// and `Reward [Q/f]` headers that were already stating those units. One
+/// rendering per cell settles both, and drops the widest reward cell from 15
+/// columns to 12.
+fn avail_cell(m: &Model, s: &ShardRow, col: usize, fw: usize) -> String {
+    match col {
+        0 => avail_marker(m, s).to_string(),
+        1 => center_trunc(&s.filter_hex, fw),
+        2 => s.active_provers.to_string(),
+        3 => s.ring.to_string(),
+        4 => fmt_mb(&s.shard_size),
+        5 => s.data_shards.to_string(),
+        _ => fmt_reward(&s.estimated_reward),
+    }
+}
+
+fn avail_marker(m: &Model, s: &ShardRow) -> &'static str {
+    if m.avail_selected.contains(&s.filter_key) {
+        "[x]"
+    } else {
+        "[ ]"
+    }
+}
+
+fn avail_header(m: &Model, idx: usize) -> String {
+    header_text(
+        AVAIL_COL_NAMES[idx],
+        idx,
+        m.avail_sort_col,
+        m.avail_sort_asc,
+        m.avail_col_filters
+            .get(&idx)
+            .is_some_and(|cf| cf.is_active()),
+        m.column_sizing == ColumnSizing::Dynamic,
+    )
+}
+
+fn avail_col_widths(m: &Model, content_width: usize, sorted: &[ShardRow]) -> (Vec<usize>, usize) {
+    match m.column_sizing {
+        ColumnSizing::Dynamic => avail_widths_measured(m, content_width, sorted),
+        ColumnSizing::Fixed => avail_widths_fixed(m, content_width, sorted),
+    }
+}
+
+/// Same rule as the allocations panel.
+fn avail_widths_measured(
+    m: &Model,
+    content_width: usize,
+    sorted: &[ShardRow],
+) -> (Vec<usize>, usize) {
+    let n = AVAIL_COL_NAMES.len();
+    let mut widths: Vec<usize> = (0..n)
+        .map(|c| {
+            col_width(
+                &avail_header(m, c),
+                sorted.iter().map(|s| avail_cell(m, s, c, 0).len()),
+            )
+        })
+        .collect();
+
+    let cap = filter_cap(
+        &avail_header(m, 1),
+        sorted.iter().map(|s| s.filter_hex.len()),
+    );
+    let fw = filter_width(content_width, &widths, n, cap);
+    widths[1] = fw;
+    (widths, fw)
+}
+
+fn avail_widths_fixed(m: &Model, content_width: usize, sorted: &[ShardRow]) -> (Vec<usize>, usize) {
+    let shards_w = fit(
+        SHARDS_WIDTH,
+        sorted.iter().map(|s| avail_cell(m, s, 5, 0).len()),
+    );
+    let reward_w = fit(
+        REWARD_WIDTH,
+        sorted.iter().map(|s| avail_cell(m, s, 6, 0).len()),
+    );
+    let grown = (shards_w - SHARDS_WIDTH) + (reward_w - REWARD_WIDTH);
+    let mut fw = content_width.saturating_sub(AVAIL_FIXED_WIDTH + grown);
     for &col in &AVAIL_FILTERABLE_COLS {
         if col == 1 {
             continue;
@@ -385,8 +611,8 @@ fn avail_col_widths(m: &Model, content_width: usize) -> (Vec<usize>, usize) {
         PROVERS_WIDTH,
         RING_WIDTH,
         SIZE_WIDTH,
-        SHARDS_WIDTH,
-        REWARD_WIDTH,
+        shards_w,
+        reward_w,
     ];
     for &col in &AVAIL_FILTERABLE_COLS {
         if col == 1 {
@@ -411,21 +637,12 @@ fn render_avail_panel(m: &mut Model, sorted: &[ShardRow], area: Rect) -> Vec<Lin
         }
         return vec![Line::from("  No available shards")];
     }
-    let (widths, fw) = avail_col_widths(m, content_width);
+    let (widths, fw) = avail_col_widths(m, content_width, sorted);
     let filter_hi = m.active_filter_col_idx();
 
     let mut hdr_spans: Vec<Span> = Vec::new();
-    for (i, name) in AVAIL_COL_NAMES.iter().enumerate() {
-        let w = widths[i];
-        let mut disp = name.to_string();
-        if m.avail_col_filters.get(&i).is_some_and(|cf| cf.is_active()) {
-            disp.push('*');
-        }
-        if m.avail_sort_col == i as i32 {
-            let ind = if m.avail_sort_asc { "^|" } else { "v|" };
-            disp = format!("{ind}{disp}");
-        }
-        let cell = format!("{:>w$}", disp, w = w);
+    for i in 0..AVAIL_COL_NAMES.len() {
+        let cell = format!("{:>w$}", avail_header(m, i), w = widths[i]);
         let style = if m.sort_mode && !m.focus.is_alloc() && m.sort_highlight_col == i {
             Style::new().bg(PRIMARY).fg(TEXT).add_modifier(Modifier::BOLD)
         } else if m.avail_filter_mode
@@ -450,23 +667,12 @@ fn render_avail_panel(m: &mut Model, sorted: &[ShardRow], area: Rect) -> Vec<Lin
 
     for i in m.avail_offset..end {
         let s = &sorted[i];
-        let marker = if m.avail_selected.contains(&s.filter_key) {
-            "[x]"
-        } else {
-            "[ ]"
-        };
         let selected = i == m.avail_cursor && !m.focus.is_alloc();
 
         if selected {
-            let cells = [
-                format!("{:>w$}", marker, w = widths[0]),
-                format!("{:>w$}", center_trunc(&s.filter_hex, fw), w = widths[1]),
-                format!("{:>w$}", s.active_provers, w = widths[2]),
-                format!("{:>w$}", s.ring, w = widths[3]),
-                format!("{:>w$}", fmt_mb(&s.shard_size), w = widths[4]),
-                format!("{:>w$}", s.data_shards, w = widths[5]),
-                format!("{:>w$}", fmt_reward(&s.estimated_reward), w = widths[6]),
-            ];
+            let cells: Vec<String> = (0..widths.len())
+                .map(|c| format!("{:>w$}", avail_cell(m, s, c, fw), w = widths[c]))
+                .collect();
             let padded = format!("{:<width$}", cells.join(" "), width = content_width);
             lines.push(Line::from(Span::styled(
                 padded,
@@ -474,32 +680,15 @@ fn render_avail_panel(m: &mut Model, sorted: &[ShardRow], area: Rect) -> Vec<Lin
             )));
         } else {
             // Non-selected: size uses human-readable storage; ring colored.
-            let cells = [
-                (format!("{:>w$}", marker, w = widths[0]), None),
-                (format!("{:>w$}", center_trunc(&s.filter_hex, fw), w = widths[1]), None),
-                (format!("{:>w$}", s.active_provers, w = widths[2]), None),
-                (
-                    format!("{:>w$}", s.ring, w = widths[3]),
-                    m.color_coding.then(|| ring_color(s.ring)),
-                ),
-                (
-                    format!("{:>w$}", format_storage(bigint_to_u64(&s.shard_size)), w = widths[4]),
-                    None,
-                ),
-                (format!("{:>w$}", s.data_shards, w = widths[5]), None),
-                (
-                    format!("{:>w$}", format!("{} Q/f", fmt_reward(&s.estimated_reward)), w = widths[6]),
-                    None,
-                ),
-            ];
             let mut spans: Vec<Span> = Vec::new();
-            for (ci, (cell, color)) in cells.into_iter().enumerate() {
-                if ci > 0 {
+            for c in 0..widths.len() {
+                if c > 0 {
                     spans.push(Span::raw(" "));
                 }
-                spans.push(match color {
-                    Some(c) => Span::styled(cell, Style::new().fg(c)),
-                    None => Span::raw(cell),
+                let cell = format!("{:>w$}", avail_cell(m, s, c, fw), w = widths[c]);
+                spans.push(match c {
+                    3 if m.color_coding => Span::styled(cell, Style::new().fg(ring_color(s.ring))),
+                    _ => Span::raw(cell),
                 });
             }
             lines.push(Line::from(spans));
@@ -586,7 +775,7 @@ fn help_line(m: &Model) -> Line<'static> {
     let filters_active = m.has_active_filters();
 
     // (key, desc, action-tag)
-    let entries: [(&str, &str, &str); 18] = [
+    let entries: [(&str, &str, &str); 19] = [
         ("tab", "switch", ""),
         ("↑/k", "up", ""),
         ("↓/j", "down", ""),
@@ -603,6 +792,7 @@ fn help_line(m: &Model) -> Line<'static> {
         ("s", "sort", ""),
         ("f", "filter", "Filter"),
         ("C", "colors", "ColorCoding"),
+        ("w", "widths", "ColumnSizing"),
         ("h", "help", ""),
         ("q", "quit", ""),
     ];
@@ -622,6 +812,13 @@ fn help_line(m: &Model) -> Line<'static> {
             }
             "ColorCoding" => {
                 if m.color_coding {
+                    Style::new().fg(SUCCESS)
+                } else {
+                    Style::new().fg(HELP)
+                }
+            }
+            "ColumnSizing" => {
+                if m.column_sizing == ColumnSizing::Dynamic {
                     Style::new().fg(SUCCESS)
                 } else {
                     Style::new().fg(HELP)
@@ -741,6 +938,7 @@ fn render_help_screen(f: &mut Frame, m: &Model, area: Rect) {
         sec("General"),
         kv("R", "Force data refresh"),
         kv("C", "Toggle color-coding of Ring, Status and Mode columns"),
+        kv("w", "Column widths: sized to content (default) or fixed"),
         kv("h", "Toggle this help screen"),
         kv("q / Ctrl+C", "Quit"),
         Line::from(""),
@@ -802,4 +1000,207 @@ fn render_join_picker(f: &mut Frame, m: &mut Model, area: Rect) {
         Style::new().fg(HELP),
     )));
     f.render_widget(Paragraph::new(lines), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One allocations row. Only the fields that reach a cell are meaningful.
+    fn row(
+        hex: &str,
+        provers: u32,
+        shards: u64,
+        worker: i64,
+        next: &str,
+        dflt: &str,
+    ) -> AllocationRow {
+        AllocationRow {
+            filter: Vec::new(),
+            filter_key: hex.to_string(),
+            filter_hex: hex.to_string(),
+            status: 1,
+            status_name: "joining".to_string(),
+            ring: 5,
+            active_provers: provers,
+            shard_size: BigInt::from(0),
+            data_shards: shards,
+            estimated_reward: BigInt::from(0),
+            join_frame: 0,
+            leave_frame: 0,
+            worker_id: worker,
+            next_action: next.to_string(),
+            default_action: dflt.to_string(),
+            manually_managed: false,
+            confirm_frame: 0,
+            leave_confirm_frame: 0,
+            epoch: 0,
+            last_active_frame: 0,
+        }
+    }
+
+    fn shard(hex: &str, size: u64, reward: u64) -> ShardRow {
+        ShardRow {
+            filter: Vec::new(),
+            filter_key: hex.to_string(),
+            filter_hex: hex.to_string(),
+            active_provers: 42,
+            ring: 1,
+            shard_size: BigInt::from(size),
+            data_shards: 2,
+            estimated_reward: BigInt::from(reward),
+        }
+    }
+
+    /// The cursor row is the same row. It used to print size in an adaptive
+    /// unit and suffix the reward with ` Q/f`, so moving the cursor rewrote
+    /// two cells of whichever row it landed on.
+    #[test]
+    fn the_cursor_does_not_change_what_a_row_says() {
+        let m = Model::new();
+        let rows = [
+            shard(&format!("{:064x}", 1), 0, 0),
+            shard(&format!("{:064x}", 2), 12_396, 4_498),
+            shard(&format!("{:064x}", 3), 6_688_000_000, 768_047),
+        ];
+        for s in &rows {
+            for c in 0..AVAIL_COL_NAMES.len() {
+                // Rendering is now independent of the cursor by construction;
+                // this pins the reward cell to the header's unit.
+                let cell = avail_cell(&m, s, c, 64);
+                assert!(!cell.contains("Q/f"), "column {c} repeats the header unit: {cell}");
+            }
+        }
+        // Reward stops carrying its unit, so the column fits its header.
+        let (w, _) = avail_col_widths(&m, 154, &rows);
+        assert_eq!(w[6], avail_header(&m, 6).len());
+    }
+
+    /// The table as reported: 15 joining allocations, sorted ascending on
+    /// Worker, none of them in a confirm window.
+    fn joining_table() -> Vec<AllocationRow> {
+        (1..=15)
+            .map(|i| {
+                row(
+                    &format!("{:064x}", i),
+                    57,
+                    10_076_371,
+                    i as i64,
+                    "confirmed",
+                    "active@e972",
+                )
+            })
+            .collect()
+    }
+
+    fn fixed() -> Model {
+        Model {
+            column_sizing: ColumnSizing::Fixed,
+            ..Model::new()
+        }
+    }
+
+    #[test]
+    fn header_text_decorates_and_underscores() {
+        assert_eq!(header_text("Worker", 7, 7, true, false, false), "^|Worker");
+        assert_eq!(header_text("Worker", 7, 7, false, false, false), "v|Worker");
+        assert_eq!(header_text("Ring", 3, 7, true, true, false), "Ring*");
+        assert_eq!(header_text("Ring", 3, 3, true, true, false), "^|Ring*");
+        // Measured columns sit one space apart, so the spaces inside a name
+        // become underscores to keep the pairs readable.
+        assert_eq!(
+            header_text("Default Action", 11, 7, true, false, true),
+            "Default_Action"
+        );
+        assert_eq!(
+            header_text("Default Action", 11, 7, true, false, false),
+            "Default Action"
+        );
+    }
+
+    #[test]
+    fn every_column_is_sized_to_its_own_content() {
+        let m = Model::new(); // Dynamic, sorted ascending on Worker
+        let rows = joining_table();
+        let (w, fw) = alloc_col_widths(&m, 154, &rows);
+
+        assert_eq!(
+            w,
+            vec![
+                6,  // "Select"
+                51, // Filter — what the pane has left
+                7,  // "Provers"
+                4,  // "Ring"
+                9,  // "Size_[MB]"
+                8,  // "10076371", wider than "Shards"
+                12, // "Reward_[Q/f]"
+                8,  // "^|Worker"
+                7,  // "joining", wider than "Status"
+                4,  // "Mode"
+                11, // "Next_Action", wider than "confirmed"
+                14, // "Default_Action", wider than "active@e972"
+            ]
+        );
+        assert_eq!(fw, 51);
+        // 12 columns + 11 separators + 2 borders fill the pane exactly.
+        assert_eq!(w.iter().sum::<usize>() + 11 + 2, 154);
+    }
+
+    #[test]
+    fn fixed_sizing_reproduces_the_historical_layout() {
+        let (w, fw) = alloc_col_widths(&fixed(), 154, &joining_table());
+        assert_eq!(w, vec![6, 20, 7, 5, 10, 8, 14, 9, 12, 4, 30, 16]);
+        assert_eq!(fw, 20);
+        assert_eq!(w.iter().sum::<usize>() + 11, 152);
+        // 30 columns of Next Action for a 9-column value, in a row 152 wide.
+        assert_eq!(w[10], NEXT_ACTION_WIDTH);
+    }
+
+    #[test]
+    fn no_cell_overflows_its_column() {
+        for m in [Model::new(), fixed()] {
+            let rows = joining_table();
+            let (w, fw) = alloc_col_widths(&m, 154, &rows);
+            for (c, width) in w.iter().enumerate() {
+                for a in &rows {
+                    let cell = alloc_cell(&m, a, c, fw);
+                    assert!(
+                        cell.len() <= *width,
+                        "column {c} is {width} wide but a cell needs {}",
+                        cell.len()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn next_action_widens_when_a_confirm_window_opens() {
+        let m = Model::new();
+        let mut rows = joining_table();
+        let (before, before_fw) = alloc_col_widths(&m, 154, &rows);
+        rows[3].next_action = "reject | confirm now".to_string();
+        let (after, after_fw) = alloc_col_widths(&m, 154, &rows);
+
+        assert_eq!(before[10], 11);
+        assert_eq!(after[10], 20);
+        // Filter gives back exactly what Next Action took; the row still fits.
+        assert_eq!(before_fw - after_fw, 9);
+        assert_eq!(after.iter().sum::<usize>() + 11 + 2, 154);
+    }
+
+    #[test]
+    fn filter_takes_the_slack_and_gives_it_back_first() {
+        let m = Model::new();
+        let rows = joining_table();
+        // Wide pane: Filter stops at the longest hex rather than padding on.
+        assert_eq!(alloc_col_widths(&m, 300, &rows).1, 64);
+        assert_eq!(alloc_col_widths(&m, 167, &rows).1, 64);
+        // Narrower: Filter absorbs the shortfall…
+        assert_eq!(alloc_col_widths(&m, 154, &rows).1, 51);
+        assert_eq!(alloc_col_widths(&m, 118, &rows).1, 15);
+        // …down to the floor, past which the row is clipped rather than shrunk.
+        assert_eq!(alloc_col_widths(&m, 115, &rows).1, MIN_FILTER_WIDTH);
+        assert_eq!(alloc_col_widths(&m, 40, &rows).1, MIN_FILTER_WIDTH);
+    }
 }


### PR DESCRIPTION
**Base:** `2b96656e`

Both `prover manage` tables use a fixed width per column, which is wrong in both directions.

**Too narrow.** `format!("{:>w$}", ..)` doesn't clip, so an 8-digit shard count on a multi-GB allocation renders one character long and shifts every column after it — and only on those rows, so the table goes ragged.

**Too wide.** `Next Action` reserves 30 columns for its worst case (`Reject | Confirm@f<frame>`) and `Status` 12 for `ExpiredLeave`, on every row of every node, whether or not any allocation is in that state. On a node whose allocations are all joining that is 21 blank columns per row in `Next Action` alone — and the row can't fit a terminal under 146 columns, so `Default Action` is clipped off the right edge while those blanks survive.

Both are the same defect. Each column now takes its printed header or its widest cell, whichever is longer, one space apart, remeasured each frame from the rows in the table. `Filter` is sized last from what the pane has left,
bounded by the longest hex it holds: it is the only column already truncated for display, so it is both the one that can grow usefully and the one that can give way without losing a value outright. The floor moves from 146 columns
to 115.

Spaces inside a header become underscores in this layout, since measured columns sit one space apart and `Next Action Default Action` gives no way to see where one header ends.

`w` toggles back to the fixed layout, which keeps the Shards and reward growth so the ragged-row bug stays fixed in both. Content sizing is the default.

Cell values now start lower-case and headers keep the capital — the table had `Joining` sitting next to `active@e972` on the same row. That covers the status labels, the action hints (`pause | leave`, `reject | confirm now`) and the Mode cell, which drops from two definitions to one shared by the cell and its column filter.

Sizing and rendering now share one definition of each cell's and each header's text; measuring a column against one string and drawing another is how `Shards` came to overflow. That surfaced a live inconsistency in the available panel, where the cursor row prints size and reward differently from every other row — both variants are now measured, so moving the cursor cannot change the layout.

A live node's 15-allocation table, sorted on Worker, in a 154-column terminal:

```
w = fixed
|Select               Filter Provers  Ring  Size [MB]   Shards   Reward [Q/f]  ^|Worker       Status Mode                    Next Action   Default Action|
|   [ ] 11558584...94d90c000      44     3     6375.2 10067592    ~0.00192011         3      joining    a                      confirmed      active@e972|
|   [ ] 11558584...94d90c000      57     5     6380.8 10076371    ~0.00048014         4      joining    a                      confirmed      active@e972|

w = dynamic
|Select                                              Filter Provers Ring Size_[MB]   Shards Reward_[Q/f] ^|Worker  Status Mode Next_Action Default_Action|
|   [ ] 1155858468e8b1e40cdf6e0a...6e0a3b7c9d2126794d90c000      44    3    6375.2 10067592  ~0.00192011        3 joining    a   confirmed    active@e972|
|   [ ] 1155858468e8b1e40cdf6e0a...6e0a3b7c9d2126794d90c000      57    5    6380.8 10076371  ~0.00048014        4 joining    a   confirmed    active@e972|
```

Filter hex is a placeholder above. Same 152 drawable columns either way; the difference is that 31 of them stop being blanks, and `Filter` goes from 20 characters of hex to 51.

Rendering-only change; no behavior outside the TUI layout. Six unit tests cover both layouts, the widths above, the invariant that no cell overflows its column, the widening when a confirm window opens, and the `Filter` floor —
`cargo test -p quil-client`, 67 passed.
