### PR TITLE
fix: serve app shard frames from worker-owned stores

### DIFF
--- a/crates/quil-engine/src/cw_app_seams.rs
+++ b/crates/quil-engine/src/cw_app_seams.rs
@@ -106,7 +106,6 @@ pub fn app_frame_from_state(
         storage_attestation,
     }
 }
-
 /// Frame identity (`Poseidon(output)[..32]`) as the consensus digest — identical
 /// scheme to global (`AppShardState`/`GlobalFrame` share `compute_output_identity`).
 fn app_frame_digest(frame: &AppShardFrame) -> Option<Digest> {
@@ -404,6 +403,16 @@ pub struct AppConsensusCwHandle {
     pub shutdown: Arc<std::sync::atomic::AtomicBool>,
 }
 
+impl Drop for AppConsensusCwHandle {
+    fn drop(&mut self) {
+        // The commonware host runs independently of the app engine's tokio
+        // task. Ensure aborting/dropping that engine cannot leave an old-shard
+        // consensus host alive after reassignment or deallocation.
+        self.shutdown
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
 /// Assemble + start the simplex-backed app-shard consensus for one shard.
 /// Must be called from within the node's tokio runtime (spawns the outbound
 /// drain there); the engine runs on its own runtime thread.
@@ -497,6 +506,22 @@ pub fn activate_app_consensus_cw(
 mod tests {
     use super::*;
     use quil_types::crypto::Signer as _;
+
+    #[test]
+    fn dropping_consensus_handle_requests_host_shutdown() {
+        let (a, _arx) = tokio::sync::mpsc::unbounded_channel();
+        let (b, _brx) = tokio::sync::mpsc::unbounded_channel();
+        let (c, _crx) = tokio::sync::mpsc::unbounded_channel();
+        let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let _handle = AppConsensusCwHandle {
+                inbound: [a, b, c],
+                ingest_block: Arc::new(|_| {}),
+                shutdown: shutdown.clone(),
+            };
+        }
+        assert!(shutdown.load(std::sync::atomic::Ordering::Acquire));
+    }
 
     #[test]
     fn app_committee_builds_and_scopes_by_shard() {

--- a/crates/quil-engine/src/remote_worker.rs
+++ b/crates/quil-engine/src/remote_worker.rs
@@ -15,7 +15,7 @@ use std::sync::Mutex;
 
 use tokio::sync::mpsc;
 use tonic::transport::Channel;
-use tracing::{debug, error, info, warn};
+use tracing::{info, warn};
 
 use quil_types::error::{QuilError, Result};
 
@@ -29,6 +29,9 @@ struct RemoteWorkerState {
     endpoint: String,
     /// Currently assigned filter.
     filter: Vec<u8>,
+    /// Last filter acknowledged by the worker's Respawn service. Public frame
+    /// reads resolve against actual state, not allocator intent.
+    active_filter: Vec<u8>,
     /// Frame number when a join proposal was submitted for this worker.
     pending_filter_frame: u64,
     /// Operator-set: skip this worker during auto-allocation.
@@ -41,15 +44,16 @@ struct RemoteWorkerState {
     channel: Option<Channel>,
     /// Whether the worker is reachable.
     connected: bool,
-    /// Whether a `start_consensus=true` Respawn is owed to this worker. Set when
-    /// the allocator asks to start consensus while the worker's channel is down
-    /// (a cluster worker that connects AFTER its alloc went Active). `connect_all`
-    /// re-issues the Respawn once the channel comes up. Without this the deferred
-    /// Respawn (remote_worker.rs "consensus not yet started"/"deferred") was lost
-    /// and the worker never activated.
-    wants_consensus: bool,
+    /// Monotonic assignment version used to discard superseded Respawn work.
+    assignment_generation: u64,
+    /// A Respawn (including an empty-filter deallocation) still needs an ack.
+    respawn_pending: bool,
+    /// Command payload is separate from desired assignment: a Joining worker is
+    /// assigned a filter in manager state but commanded idle until activation.
+    respawn_filter: Vec<u8>,
+    /// Serializes Respawn RPCs for this core so A -> B cannot land as B -> A.
+    respawn_lock: std::sync::Arc<tokio::sync::Mutex<()>>,
 }
-
 /// Manages workers running on remote machines via gRPC.
 ///
 /// Implements the `WorkerManager` trait so it can be used as a
@@ -123,12 +127,16 @@ impl RemoteWorkerManager {
                 core_id,
                 endpoint,
                 filter: Vec::new(),
+                active_filter: Vec::new(),
                 pending_filter_frame: 0,
                 manually_managed: false,
                 allocated: false,
                 channel: None,
                 connected: false,
-                wants_consensus: false,
+                assignment_generation: 0,
+                respawn_pending: false,
+                respawn_filter: Vec::new(),
+                respawn_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
             });
         }
 
@@ -172,50 +180,46 @@ impl RemoteWorkerManager {
     /// reconnect / duplicate deferred-Respawn), so it only acts on the initial
     /// connect or after a disconnect clears the channel.
     pub async fn connect_all(&self) {
-        let endpoints: Vec<(u32, String)> = {
+        let (endpoints, pending_connected): (Vec<(u32, String)>, Vec<(u32, u64)>) = {
             let workers = self.workers.lock().unwrap();
-            workers.values()
+            let endpoints = workers
+                .values()
                 .filter(|w| w.channel.is_none())
                 .map(|w| (w.core_id, w.endpoint.clone()))
-                .collect()
+                .collect();
+            let pending = workers
+                .values()
+                .filter(|w| w.channel.is_some() && w.respawn_pending)
+                .map(|w| (w.core_id, w.assignment_generation))
+                .collect();
+            (endpoints, pending)
         };
-        if endpoints.is_empty() {
-            return;
-        }
 
         for (core_id, endpoint) in endpoints {
             match connect_to_worker(&endpoint, self.client_tls.as_ref()).await {
                 Ok(channel) => {
-                    let (owed_filter, chan) = {
+                    let pending_generation = {
                         let mut workers = self.workers.lock().unwrap();
                         if let Some(w) = workers.get_mut(&core_id) {
                             w.channel = Some(channel.clone());
                             w.connected = true;
-                            // If a start_consensus Respawn was deferred while the
-                            // channel was down, it's owed now.
-                            let owed = if w.wants_consensus && !w.filter.is_empty() {
-                                Some(w.filter.clone())
+                            if w.respawn_pending {
+                                Some(w.assignment_generation)
                             } else {
                                 None
-                            };
-                            (owed, channel)
+                            }
                         } else {
-                            (None, channel)
+                            None
                         }
                     };
                     info!(core_id, endpoint = %endpoint, "connected to remote worker");
-                    let _ = self.event_tx.send(RemoteWorkerEvent::Connected { core_id }).await;
-                    // Re-issue the deferred Respawn now that the worker is up.
-                    if let Some(filter) = owed_filter {
-                        info!(core_id, filter = hex::encode(&filter), "re-issuing deferred Respawn on connect");
-                        let mut client =
-                            quil_types::proto::node::data_ipc_service_client::DataIpcServiceClient::new(chan);
-                        let req = tonic::Request::new(quil_types::proto::node::RespawnRequest {
-                            filter,
-                        });
-                        if let Err(e) = client.respawn(req).await {
-                            warn!(core_id, error = %e, "deferred Respawn failed");
-                        }
+                    let _ = self
+                        .event_tx
+                        .send(RemoteWorkerEvent::Connected { core_id })
+                        .await;
+                    if let Some(generation) = pending_generation {
+                        Self::apply_pending_respawn(self.workers.clone(), core_id, generation)
+                            .await;
                     }
                 }
                 Err(e) => {
@@ -227,6 +231,84 @@ impl RemoteWorkerManager {
                     );
                 }
             }
+        }
+
+        // A server-side failure need not tear down the tonic channel. Retry the
+        // latest pending generation on the manager's regular connect poll.
+        for (core_id, generation) in pending_connected {
+            Self::apply_pending_respawn(self.workers.clone(), core_id, generation).await;
+        }
+    }
+
+    /// Apply one assignment version after taking the per-core command lock.
+    /// The generation check coalesces queued assignments, while the lock makes
+    /// an already-in-flight A assignment finish before the newer B assignment.
+    async fn apply_pending_respawn(
+        workers: std::sync::Arc<Mutex<HashMap<u32, RemoteWorkerState>>>,
+        core_id: u32,
+        generation: u64,
+    ) {
+        let command_lock = {
+            let workers = workers.lock().unwrap();
+            workers
+                .get(&core_id)
+                .map(|worker| worker.respawn_lock.clone())
+        };
+        let Some(command_lock) = command_lock else {
+            return;
+        };
+        let _command_guard = command_lock.lock().await;
+
+        let command = {
+            let workers = workers.lock().unwrap();
+            workers.get(&core_id).and_then(|worker| {
+                (worker.assignment_generation == generation && worker.respawn_pending)
+                    .then(|| (worker.respawn_filter.clone(), worker.channel.clone()))
+            })
+        };
+        let Some((filter, Some(channel))) = command else {
+            return;
+        };
+
+        let mut client =
+            quil_types::proto::node::data_ipc_service_client::DataIpcServiceClient::new(channel);
+        let request = tonic::Request::new(quil_types::proto::node::RespawnRequest {
+            filter: filter.clone(),
+        });
+        match tokio::time::timeout(std::time::Duration::from_secs(10), client.respawn(request))
+            .await
+        {
+            Ok(Ok(_)) => {
+                let mut workers = workers.lock().unwrap();
+                if let Some(worker) = workers.get_mut(&core_id) {
+                    // Even a superseded command changed the worker's actual
+                    // state. A queued newer generation will update this again
+                    // after its own acknowledgement.
+                    worker.active_filter = filter.clone();
+                    if worker.assignment_generation == generation {
+                        worker.respawn_pending = false;
+                    }
+                }
+                info!(
+                    core_id,
+                    filter = hex::encode(&filter),
+                    generation,
+                    "remote worker Respawn acknowledged"
+                );
+            }
+            Ok(Err(error)) => warn!(
+                core_id,
+                filter = hex::encode(&filter),
+                generation,
+                %error,
+                "remote worker Respawn RPC failed"
+            ),
+            Err(_) => warn!(
+                core_id,
+                filter = hex::encode(&filter),
+                generation,
+                "remote worker Respawn RPC timed out"
+            ),
         }
     }
 
@@ -261,30 +343,108 @@ impl RemoteWorkerManager {
 
     /// Send a Respawn command to a remote worker via gRPC.
     pub async fn send_respawn(&self, core_id: u32, filter: &[u8]) -> Result<()> {
-        let channel = {
+        let generation = {
+            let mut workers = self.workers.lock().unwrap();
+            let worker = workers.get_mut(&core_id).ok_or_else(|| {
+                QuilError::InvalidArgument(format!("no remote worker with core_id {core_id}"))
+            })?;
+            if worker.channel.is_none() {
+                return Err(QuilError::Internal(format!(
+                    "worker {core_id} not connected"
+                )));
+            }
+            worker.filter = filter.to_vec();
+            worker.assignment_generation = worker.assignment_generation.wrapping_add(1);
+            worker.respawn_pending = true;
+            worker.respawn_filter = filter.to_vec();
+            worker.assignment_generation
+        };
+        Self::apply_pending_respawn(self.workers.clone(), core_id, generation).await;
+        let still_pending = self
+            .workers
+            .lock()
+            .unwrap()
+            .get(&core_id)
+            .is_some_and(|worker| {
+                worker.assignment_generation == generation && worker.respawn_pending
+            });
+        if still_pending {
+            Err(QuilError::Internal(format!(
+                "worker {core_id} Respawn was not acknowledged"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Proxy an app-shard frame read to the connected worker assigned to
+    /// `filter`. The worker validates its actual active filter, so desired
+    /// manager state cannot expose an old shard during a failed/racing Respawn.
+    pub async fn get_app_shard_frame(
+        &self,
+        filter: &[u8],
+        frame_number: u64,
+    ) -> std::result::Result<Option<quil_types::proto::global::AppShardFrame>, tonic::Status> {
+        enum Route {
+            Active(u32, Option<Channel>),
+            Pending(u32),
+            Missing,
+        }
+        let route = {
             let workers = self.workers.lock().unwrap();
-            workers.get(&core_id)
-                .and_then(|w| w.channel.clone())
-                .ok_or_else(|| QuilError::Internal(
-                    format!("worker {} not connected", core_id)
-                ))?
+            match workers.values().find(|worker| worker.filter == filter) {
+                Some(worker) if worker.active_filter == filter && !worker.respawn_pending => {
+                    Route::Active(worker.core_id, worker.channel.clone())
+                }
+                Some(worker) if worker.respawn_pending && worker.respawn_filter == filter => {
+                    Route::Pending(worker.core_id)
+                }
+                _ => Route::Missing,
+            }
+        };
+        let (core_id, channel) = match route {
+            Route::Active(core_id, channel) => (core_id, channel),
+            Route::Pending(core_id) => {
+                return Err(tonic::Status::unavailable(format!(
+                    "worker {core_id} shard assignment is pending"
+                )))
+            }
+            Route::Missing => return Ok(None),
+        };
+        let Some(channel) = channel else {
+            return Err(tonic::Status::unavailable(format!(
+                "worker {core_id} assigned to shard is not connected"
+            )));
         };
 
-        // Call the DataIPC Respawn RPC
-        let mut client = quil_types::proto::node::data_ipc_service_client::DataIpcServiceClient::new(channel);
-        let request = tonic::Request::new(quil_types::proto::node::RespawnRequest {
+        let mut client =
+            quil_types::proto::global::app_shard_service_client::AppShardServiceClient::new(
+                channel,
+            )
+            .max_decoding_message_size(64 * 1024 * 1024)
+            .max_encoding_message_size(64 * 1024 * 1024);
+        let request = tonic::Request::new(quil_types::proto::global::GetAppShardFrameRequest {
             filter: filter.to_vec(),
+            frame_number,
         });
-
-        match client.respawn(request).await {
-            Ok(_) => {
-                info!(core_id, filter = hex::encode(filter), "remote worker respawned");
-                Ok(())
-            }
-            Err(e) => {
-                error!(core_id, error = %e, "remote worker respawn failed");
-                Err(QuilError::Internal(format!("respawn failed: {}", e)))
-            }
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client.get_app_shard_frame(request),
+        )
+        .await
+        {
+            Ok(Ok(response)) => Ok(response.into_inner().frame),
+            Ok(Err(status)) if status.code() == tonic::Code::NotFound => Ok(None),
+            Ok(Err(status)) => Err(tonic::Status::new(
+                status.code(),
+                format!(
+                    "worker {core_id} app-shard read failed: {}",
+                    status.message()
+                ),
+            )),
+            Err(_) => Err(tonic::Status::deadline_exceeded(format!(
+                "worker {core_id} app-shard read timed out"
+            ))),
         }
     }
 
@@ -300,51 +460,31 @@ impl RemoteWorkerManager {
 }
 
 impl WorkerManager for RemoteWorkerManager {
-    fn set_worker_filter(
-        &self,
-        core_id: u32,
-        filter: &[u8],
-        start_consensus: bool,
-    ) -> Result<()> {
-        let connected = {
+    fn set_worker_filter(&self, core_id: u32, filter: &[u8], start_consensus: bool) -> Result<()> {
+        let (connected, generation) = {
             let mut workers = self.workers.lock().unwrap();
             if let Some(w) = workers.get_mut(&core_id) {
                 w.filter = filter.to_vec();
-                // Remember whether consensus is owed, so `connect_all` can
-                // re-issue the Respawn if the worker connects later. A
-                // non-empty filter with start_consensus=false (Joining) clears
-                // it; an empty filter (idle) clears it too.
-                w.wants_consensus = start_consensus && !filter.is_empty();
-                w.channel.is_some()
+                w.assignment_generation = w.assignment_generation.wrapping_add(1);
+                // Every assignment transition is a real command. Joining keeps
+                // the desired filter but commands the worker idle, guaranteeing
+                // an outgoing engine cannot survive until the new allocation is
+                // activated.
+                w.respawn_pending = true;
+                w.respawn_filter = if start_consensus {
+                    filter.to_vec()
+                } else {
+                    Vec::new()
+                };
+                (w.channel.is_some(), w.assignment_generation)
             } else {
-                return Err(QuilError::InvalidArgument(
-                    format!("no remote worker with core_id {}", core_id)
-                ));
+                return Err(QuilError::InvalidArgument(format!(
+                    "no remote worker with core_id {}",
+                    core_id
+                )));
             }
         };
 
-        // Empty filter = idle slot reservation (e.g. startup
-        // pre-allocation at main.rs that creates `cores - 1` empty
-        // slots before any shard work is assigned). There is no
-        // consensus engine to (re)spawn for an empty filter; just
-        // record the binding. Falls through `start_consensus` and
-        // `connected` checks because both are irrelevant here.
-        if filter.is_empty() {
-            debug!(core_id, "remote worker idle slot recorded (no filter)");
-            return Ok(());
-        }
-
-        // `start_consensus=false` (Joining alloc, no Active prover yet)
-        // intentionally skips the Respawn — the worker stays idle until
-        // the allocation transitions to Active.
-        if !start_consensus {
-            info!(
-                core_id,
-                filter = hex::encode(filter),
-                "remote worker filter recorded (consensus not yet started)"
-            );
-            return Ok(());
-        }
         if !connected {
             // Worker hasn't connected yet. The next `connect_all` /
             // reconnect cycle is responsible for re-issuing the
@@ -362,43 +502,15 @@ impl WorkerManager for RemoteWorkerManager {
         // immediately and the lifecycle loop doesn't block on a
         // potentially slow worker.
         let workers = self.workers.clone();
-        let filter_owned = filter.to_vec();
         tokio::spawn(async move {
-            let channel = {
-                let guard = workers.lock().unwrap();
-                guard.get(&core_id).and_then(|w| w.channel.clone())
-            };
-            let Some(channel) = channel else {
-                warn!(core_id, "remote worker channel disappeared before Respawn");
-                return;
-            };
-            let mut client = quil_types::proto::node::data_ipc_service_client::DataIpcServiceClient::new(channel);
-            let request = tonic::Request::new(quil_types::proto::node::RespawnRequest {
-                filter: filter_owned.clone(),
-            });
-            match client.respawn(request).await {
-                Ok(_) => info!(
-                    core_id,
-                    filter = hex::encode(&filter_owned),
-                    "remote worker respawned"
-                ),
-                Err(e) => warn!(
-                    core_id,
-                    filter = hex::encode(&filter_owned),
-                    error = %e,
-                    "remote worker Respawn RPC failed"
-                ),
-            }
+            Self::apply_pending_respawn(workers, core_id, generation).await;
         });
         Ok(())
     }
 
     fn deallocate_worker(&self, core_id: u32) -> Result<()> {
-        let mut workers = self.workers.lock().unwrap();
-        if let Some(w) = workers.get_mut(&core_id) {
-            w.filter.clear();
-            info!(core_id, "remote worker deallocated");
-        }
+        self.set_worker_filter(core_id, &[], false)?;
+        info!(core_id, "remote worker deallocated and idle Respawn queued");
         Ok(())
     }
 
@@ -538,6 +650,106 @@ async fn connect_to_worker(
 mod tests {
     use super::*;
 
+    struct TestAppShardService {
+        calls: std::sync::Arc<std::sync::Mutex<Vec<(Vec<u8>, u64)>>>,
+    }
+
+    struct TestDataIpcService {
+        completed: std::sync::Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
+        first_started: std::sync::Arc<tokio::sync::Semaphore>,
+        release_first: std::sync::Arc<tokio::sync::Semaphore>,
+    }
+
+    #[tonic::async_trait]
+    impl quil_types::proto::node::data_ipc_service_server::DataIpcService for TestDataIpcService {
+        async fn respawn(
+            &self,
+            request: tonic::Request<quil_types::proto::node::RespawnRequest>,
+        ) -> std::result::Result<
+            tonic::Response<quil_types::proto::node::RespawnResponse>,
+            tonic::Status,
+        > {
+            let filter = request.into_inner().filter;
+            if filter == b"shard-a" {
+                self.first_started.add_permits(1);
+                self.release_first.acquire().await.unwrap().forget();
+            }
+            self.completed.lock().unwrap().push(filter);
+            Ok(tonic::Response::new(
+                quil_types::proto::node::RespawnResponse {},
+            ))
+        }
+
+        async fn create_join_proof(
+            &self,
+            _request: tonic::Request<quil_types::proto::node::CreateJoinProofRequest>,
+        ) -> std::result::Result<
+            tonic::Response<quil_types::proto::node::CreateJoinProofResponse>,
+            tonic::Status,
+        > {
+            Ok(tonic::Response::new(
+                quil_types::proto::node::CreateJoinProofResponse {
+                    response: Vec::new(),
+                },
+            ))
+        }
+
+        async fn set_halted(
+            &self,
+            _request: tonic::Request<quil_types::proto::node::SetHaltedRequest>,
+        ) -> std::result::Result<
+            tonic::Response<quil_types::proto::node::SetHaltedResponse>,
+            tonic::Status,
+        > {
+            Ok(tonic::Response::new(
+                quil_types::proto::node::SetHaltedResponse {},
+            ))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl quil_types::proto::global::app_shard_service_server::AppShardService for TestAppShardService {
+        async fn get_app_shard_frame(
+            &self,
+            request: tonic::Request<quil_types::proto::global::GetAppShardFrameRequest>,
+        ) -> std::result::Result<
+            tonic::Response<quil_types::proto::global::AppShardFrameResponse>,
+            tonic::Status,
+        > {
+            let req = request.into_inner();
+            self.calls
+                .lock()
+                .unwrap()
+                .push((req.filter.clone(), req.frame_number));
+            let mut header = quil_types::proto::global::FrameHeader::default();
+            header.address = req.filter;
+            header.frame_number = req.frame_number;
+            header.output = vec![9; 5 * 1024 * 1024];
+            Ok(tonic::Response::new(
+                quil_types::proto::global::AppShardFrameResponse {
+                    frame: Some(quil_types::proto::global::AppShardFrame {
+                        header: Some(header),
+                        requests: Vec::new(),
+                        ..Default::default()
+                    }),
+                    proof: Vec::new(),
+                },
+            ))
+        }
+
+        async fn get_app_shard_proposal(
+            &self,
+            _request: tonic::Request<quil_types::proto::global::GetAppShardProposalRequest>,
+        ) -> std::result::Result<
+            tonic::Response<quil_types::proto::global::AppShardProposalResponse>,
+            tonic::Status,
+        > {
+            Ok(tonic::Response::new(
+                quil_types::proto::global::AppShardProposalResponse { proposal: None },
+            ))
+        }
+    }
+
     #[test]
     fn multiaddr_to_http_ipv4() {
         assert_eq!(
@@ -585,5 +797,207 @@ mod tests {
         mgr.deallocate_worker(1).unwrap();
         let workers = mgr.range_workers().unwrap();
         assert!(workers[0].filter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn proxies_frame_reads_to_assigned_worker_with_large_messages() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let service = TestAppShardService {
+            calls: calls.clone(),
+        };
+        let data_service = TestDataIpcService {
+            completed: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            first_started: std::sync::Arc::new(tokio::sync::Semaphore::new(0)),
+            release_first: std::sync::Arc::new(tokio::sync::Semaphore::new(0)),
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(
+                    quil_types::proto::global::app_shard_service_server::AppShardServiceServer::new(
+                        service,
+                    )
+                    .max_decoding_message_size(64 * 1024 * 1024)
+                    .max_encoding_message_size(64 * 1024 * 1024),
+                )
+                .add_service(
+                    quil_types::proto::node::data_ipc_service_server::DataIpcServiceServer::new(
+                        data_service,
+                    ),
+                )
+                .serve_with_shutdown(addr, async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        let manager = RemoteWorkerManager::new(
+            vec![(1, format!("http://{addr}"))],
+            "http://master:8340".into(),
+            None,
+        );
+        manager.connect_all().await;
+        manager.send_respawn(1, b"assigned-shard").await.unwrap();
+
+        let frame = manager
+            .get_app_shard_frame(b"assigned-shard", 44)
+            .await
+            .unwrap()
+            .unwrap();
+        let header = frame.header.unwrap();
+        assert_eq!(header.frame_number, 44);
+        assert_eq!(header.output.len(), 5 * 1024 * 1024);
+        assert_eq!(
+            *calls.lock().unwrap(),
+            vec![(b"assigned-shard".to_vec(), 44)]
+        );
+        assert!(manager
+            .get_app_shard_frame(b"unassigned-shard", 44)
+            .await
+            .unwrap()
+            .is_none());
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn app_shard_read_reports_an_assigned_disconnected_worker() {
+        let manager = RemoteWorkerManager::new(
+            vec![(1, "http://127.0.0.1:1".into())],
+            "http://master:8340".into(),
+            None,
+        );
+        manager
+            .set_worker_filter(1, b"assigned-shard", false)
+            .unwrap();
+        {
+            let mut workers = manager.workers.lock().unwrap();
+            let worker = workers.get_mut(&1).unwrap();
+            worker.active_filter = b"assigned-shard".to_vec();
+            worker.respawn_pending = false;
+        }
+
+        let status = manager
+            .get_app_shard_frame(b"assigned-shard", 0)
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+    }
+
+    #[tokio::test]
+    async fn serializes_reassignment_and_sends_idle_on_deallocation() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let completed = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let first_started = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let release_first = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+        let service = TestDataIpcService {
+            completed: completed.clone(),
+            first_started: first_started.clone(),
+            release_first: release_first.clone(),
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(
+                    quil_types::proto::node::data_ipc_service_server::DataIpcServiceServer::new(
+                        service,
+                    ),
+                )
+                .serve_with_shutdown(addr, async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        let manager = RemoteWorkerManager::new(
+            vec![(1, format!("http://{addr}"))],
+            "http://master:8340".into(),
+            None,
+        );
+        manager.connect_all().await;
+        manager.set_worker_filter(1, b"shard-a", true).unwrap();
+        first_started.acquire().await.unwrap().forget();
+        manager.set_worker_filter(1, b"shard-b", true).unwrap();
+        let pending = manager
+            .get_app_shard_frame(b"shard-b", 0)
+            .await
+            .unwrap_err();
+        assert_eq!(pending.code(), tonic::Code::Unavailable);
+        assert!(manager
+            .get_app_shard_frame(b"shard-a", 0)
+            .await
+            .unwrap()
+            .is_none());
+        release_first.add_permits(1);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let active = manager
+                    .workers
+                    .lock()
+                    .unwrap()
+                    .get(&1)
+                    .unwrap()
+                    .active_filter
+                    .clone();
+                if completed.lock().unwrap().len() == 2 && active == b"shard-b" {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            *completed.lock().unwrap(),
+            vec![b"shard-a".to_vec(), b"shard-b".to_vec()]
+        );
+        assert_eq!(
+            manager
+                .workers
+                .lock()
+                .unwrap()
+                .get(&1)
+                .unwrap()
+                .active_filter,
+            b"shard-b"
+        );
+
+        manager.deallocate_worker(1).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let active_is_empty = manager
+                    .workers
+                    .lock()
+                    .unwrap()
+                    .get(&1)
+                    .unwrap()
+                    .active_filter
+                    .is_empty();
+                if completed.lock().unwrap().len() == 3 && active_is_empty {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(completed.lock().unwrap()[2].is_empty());
+        assert!(manager
+            .workers
+            .lock()
+            .unwrap()
+            .get(&1)
+            .unwrap()
+            .active_filter
+            .is_empty());
+        let _ = shutdown_tx.send(());
     }
 }

--- a/crates/quil-engine/src/thread_worker.rs
+++ b/crates/quil-engine/src/thread_worker.rs
@@ -45,7 +45,6 @@ pub enum MasterToWorker {
 }
 
 /// Message from worker to master.
-#[derive(Debug)]
 pub enum WorkerToMaster {
     /// Worker has completed a respawn and is ready.
     Ready { core_id: u32 },
@@ -108,8 +107,10 @@ pub enum WorkerToMaster {
     /// per-shard frame/consensus/prover/dispatch bitmasks.
     ShardActivated {
         core_id: u32,
+        generation: u64,
         filter: Vec<u8>,
         handle: crate::app_engine::AppEngineHandle,
+        clock_store: Arc<dyn quil_types::store::ClockStore>,
     },
     /// A shard worker has torn down its `AppConsensusEngine` for
     /// `filter`. Master removes the registry entry and unsubscribes
@@ -117,8 +118,15 @@ pub enum WorkerToMaster {
     /// shard messages once we leave it).
     ShardDeactivated {
         core_id: u32,
+        generation: u64,
         filter: Vec<u8>,
     },
+}
+
+impl std::fmt::Debug for WorkerToMaster {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkerToMaster").finish_non_exhaustive()
+    }
 }
 
 /// State of a single worker thread.
@@ -404,6 +412,7 @@ impl ThreadWorkerManager {
                 rt.block_on(async move {
                     let mut current_filter: Vec<u8> = Vec::new();
                     let mut engine_cancel: Option<tokio_util::sync::CancellationToken> = None;
+                    let mut engine_generation = 0u64;
 
                     // Per-worker memory tick. Each worker owns its own RocksDB
                     // (block cache + memtables + table readers) in this thread,
@@ -469,6 +478,8 @@ impl ThreadWorkerManager {
                                                 "worker assigned to shard"
                                             );
                                             current_filter = filter.clone();
+                                            engine_generation = engine_generation.wrapping_add(1);
+                                            let generation = engine_generation;
 
                                             // Compute app address from filter
                                             let _app_address = quil_crypto::poseidon::hash_bytes_to_32(&filter)
@@ -493,6 +504,7 @@ impl ThreadWorkerManager {
                                                         .as_ref()
                                                         .map(|o| o.clock_store.clone())
                                                         .unwrap_or_else(|| deps.clock_store.clone());
+                                                    let route_clock_store = clock_store.clone();
                                                     let hypergraph = owned
                                                         .as_ref()
                                                         .map(|o| Some(o.hypergraph.clone()))
@@ -562,8 +574,10 @@ impl ThreadWorkerManager {
                                                     let _ = master_tx_clone.send(
                                                         WorkerToMaster::ShardActivated {
                                                             core_id,
+                                                            generation,
                                                             filter: filter_clone.clone(),
                                                             handle: app_handle.clone(),
+                                                            clock_store: route_clock_store,
                                                         }
                                                     ).await;
 
@@ -698,6 +712,7 @@ impl ThreadWorkerManager {
                                                     let _ = master_tx_clone.send(
                                                         WorkerToMaster::ShardDeactivated {
                                                             core_id,
+                                                            generation,
                                                             filter: filter_clone.clone(),
                                                         }
                                                     ).await;

--- a/crates/quil-engine/src/worker_node.rs
+++ b/crates/quil-engine/src/worker_node.rs
@@ -88,7 +88,6 @@ pub struct WorkerNodeConfig {
     /// DataIPC; used in tests and during master-less bring-up).
     pub channel_factory: Option<MasterChannelFactory>,
 }
-
 /// Publish-side hook for the standalone worker's outbound traffic.
 /// Today this is wired to the master's PubSubProxy; once each worker
 /// runs its own libp2p instance with a synthetic peer key (per
@@ -127,6 +126,12 @@ pub struct WorkerOnlyNode {
     inclusion_prover: Option<Arc<dyn quil_types::crypto::InclusionProver>>,
     /// Current engine handle (set after Respawn).
     engine_handle: std::sync::Mutex<Option<AppEngineHandle>>,
+    /// Top-level engine task. Aborting it is the standalone-worker equivalent
+    /// of cancelling a thread worker's per-engine cancellation token.
+    engine_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Filter served by this worker's AppShardService. Cleared before an
+    /// engine swap and set only after the replacement engine is installed.
+    active_filter: Arc<std::sync::Mutex<Vec<u8>>>,
     /// Channel for engine events back to the master stream.
     engine_event_tx: mpsc::UnboundedSender<crate::app_engine::AppEngineEvent>,
     /// Optional receiver for engine events — consumed by the
@@ -220,6 +225,8 @@ impl WorkerOnlyNode {
             execution_engine: None,
             inclusion_prover: None,
             engine_handle: std::sync::Mutex::new(None),
+            engine_task: std::sync::Mutex::new(None),
+            active_filter: Arc::new(std::sync::Mutex::new(Vec::new())),
             engine_event_tx,
             engine_event_rx: std::sync::Mutex::new(Some(engine_event_rx)),
             publish_fn: None,
@@ -375,6 +382,10 @@ impl WorkerOnlyNode {
         let ipc_service = DataIpcServiceImpl {
             worker: self.clone(),
         };
+        let app_shard_service = WorkerAppShardServiceImpl {
+            clock_store: self.clock_store.clone(),
+            active_filter: self.active_filter.clone(),
+        };
         let listen_addr = self.config.listen_addr.parse()
             .map_err(|e| QuilError::Internal(format!("bad listen addr: {}", e)))?;
 
@@ -417,6 +428,13 @@ impl WorkerOnlyNode {
                     quil_types::proto::node::data_ipc_service_server::DataIpcServiceServer::new(
                         ipc_service,
                     ),
+                )
+                .add_service(
+                    quil_types::proto::global::app_shard_service_server::AppShardServiceServer::new(
+                        app_shard_service,
+                    )
+                    .max_decoding_message_size(64 * 1024 * 1024)
+                    .max_encoding_message_size(64 * 1024 * 1024),
                 )
                 .serve_with_shutdown(listen_addr, server_cancel.cancelled())
                 .await
@@ -628,9 +646,16 @@ impl WorkerOnlyNode {
 
         // Stop existing engine and drop subscriptions for the
         // outgoing filter.
+        let old_task = self.engine_task.lock().unwrap().take();
         {
             let mut handle = self.engine_handle.lock().unwrap();
             *handle = None;
+        }
+        self.active_filter.lock().unwrap().clear();
+        if let Some(task) = old_task {
+            task.abort();
+            let _ = task.await;
+            info!(core_id, "outgoing app engine stopped");
         }
         self.unsubscribe_active_shards().await;
 
@@ -713,26 +738,24 @@ impl WorkerOnlyNode {
             },
         };
 
-        let (engine, handle) = AppConsensusEngine::new(
-            core_id,
-            filter.clone(),
-            deps,
-            self.engine_event_tx.clone(),
-        );
+        let (engine, handle) =
+            AppConsensusEngine::new(core_id, filter.clone(), deps, self.engine_event_tx.clone());
 
         // Store handle for message routing
         {
             let mut h = self.engine_handle.lock().unwrap();
             *h = Some(handle);
         }
+        *self.active_filter.lock().unwrap() = filter.clone();
 
         // Run engine in background. Pass the signer FACTORY so the engine can
         // retry starting CW (obtaining a fresh signer each attempt) until its
         // committee is buildable.
         let signer_factory = self.bls_signer_factory.clone();
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             engine.run(signer_factory).await;
         });
+        *self.engine_task.lock().unwrap() = Some(task);
 
         // Subscribe to per-shard bitmasks on the worker's own p2p so
         // peer-published shard traffic flows in. No-op when running in
@@ -1095,6 +1118,82 @@ impl quil_types::proto::node::data_ipc_service_server::DataIpcService
             .store(halted, std::sync::atomic::Ordering::Relaxed);
         Ok(tonic::Response::new(
             quil_types::proto::node::SetHaltedResponse {},
+        ))
+    }
+}
+
+// =====================================================================
+// AppShardService — direct reads from this standalone worker's store
+// =====================================================================
+
+struct WorkerAppShardServiceImpl {
+    clock_store: Arc<dyn ClockStore>,
+    active_filter: Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+#[tonic::async_trait]
+impl quil_types::proto::global::app_shard_service_server::AppShardService
+    for WorkerAppShardServiceImpl
+{
+    async fn get_app_shard_frame(
+        &self,
+        request: tonic::Request<quil_types::proto::global::GetAppShardFrameRequest>,
+    ) -> std::result::Result<
+        tonic::Response<quil_types::proto::global::AppShardFrameResponse>,
+        tonic::Status,
+    > {
+        let req = request.into_inner();
+        if req.filter.is_empty() {
+            return Err(tonic::Status::invalid_argument("filter required"));
+        }
+        if *self.active_filter.lock().unwrap() != req.filter {
+            return Ok(tonic::Response::new(
+                quil_types::proto::global::AppShardFrameResponse {
+                    frame: None,
+                    proof: Vec::new(),
+                },
+            ));
+        }
+
+        let clock_store = self.clock_store.clone();
+        let filter = req.filter;
+        let frame_number = req.frame_number;
+        let result = tokio::task::spawn_blocking(move || {
+            if frame_number == 0 {
+                clock_store.get_latest_shard_clock_frame(&filter)
+            } else {
+                clock_store.get_shard_clock_frame(&filter, frame_number, false)
+            }
+        })
+        .await
+        .map_err(|e| tonic::Status::internal(format!("worker frame read task failed: {e}")))?;
+
+        let frame = match result {
+            Ok(frame) => Some(frame),
+            Err(QuilError::NotFound(_)) => None,
+            Err(e) => {
+                return Err(tonic::Status::internal(format!(
+                    "worker app-shard frame read failed: {e}"
+                )))
+            }
+        };
+        Ok(tonic::Response::new(
+            quil_types::proto::global::AppShardFrameResponse {
+                frame,
+                proof: Vec::new(),
+            },
+        ))
+    }
+
+    async fn get_app_shard_proposal(
+        &self,
+        _request: tonic::Request<quil_types::proto::global::GetAppShardProposalRequest>,
+    ) -> std::result::Result<
+        tonic::Response<quil_types::proto::global::AppShardProposalResponse>,
+        tonic::Status,
+    > {
+        Ok(tonic::Response::new(
+            quil_types::proto::global::AppShardProposalResponse { proposal: None },
         ))
     }
 }
@@ -1476,5 +1575,67 @@ mod tests {
         // the misconfig in logs.
         let c = config_with_stream("not-a-multiaddr");
         assert_eq!(master_grpc_endpoint(&c), "http://127.0.0.1:8340");
+    }
+
+    fn app_shard_store(
+        filter: &[u8],
+        frame_number: u64,
+    ) -> Arc<quil_store::testing::InMemoryClockStore> {
+        let store = Arc::new(quil_store::testing::InMemoryClockStore::new());
+        let mut header = quil_types::proto::global::FrameHeader::default();
+        header.address = filter.to_vec();
+        header.frame_number = frame_number;
+        let frame = quil_types::proto::global::AppShardFrame {
+            header: Some(header),
+            requests: Vec::new(),
+            ..Default::default()
+        };
+        let selector = vec![7; 32];
+        let txn = store.new_transaction(false).unwrap();
+        store
+            .stage_shard_clock_frame(&selector, &frame, txn.as_ref())
+            .unwrap();
+        store
+            .commit_shard_clock_frame(filter, frame_number, &selector, txn.as_ref(), false)
+            .unwrap();
+        txn.commit().unwrap();
+        store
+    }
+
+    #[tokio::test]
+    async fn app_shard_service_reads_only_the_active_filter() {
+        use quil_types::proto::global::app_shard_service_server::AppShardService;
+
+        let filter = b"active-shard".to_vec();
+        let service = WorkerAppShardServiceImpl {
+            clock_store: app_shard_store(&filter, 31),
+            active_filter: Arc::new(std::sync::Mutex::new(filter.clone())),
+        };
+
+        let latest = service
+            .get_app_shard_frame(tonic::Request::new(
+                quil_types::proto::global::GetAppShardFrameRequest {
+                    filter: filter.clone(),
+                    frame_number: 0,
+                },
+            ))
+            .await
+            .unwrap()
+            .into_inner()
+            .frame
+            .unwrap();
+        assert_eq!(latest.header.unwrap().frame_number, 31);
+
+        let inactive = service
+            .get_app_shard_frame(tonic::Request::new(
+                quil_types::proto::global::GetAppShardFrameRequest {
+                    filter: b"old-shard".to_vec(),
+                    frame_number: 31,
+                },
+            ))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(inactive.frame.is_none());
     }
 }

--- a/crates/quil-node/Cargo.toml
+++ b/crates/quil-node/Cargo.toml
@@ -94,3 +94,4 @@ tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 [dev-dependencies]
 tempfile = "3"
 flate2 = "1"
+quil-store = { path = "../quil-store", features = ["test-utils"] }

--- a/crates/quil-node/src/master_node/app_shard_router.rs
+++ b/crates/quil-node/src/master_node/app_shard_router.rs
@@ -1,0 +1,257 @@
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use quil_rpc::stub_services::AppShardFrameProvider;
+use quil_types::error::QuilError;
+use quil_types::proto::global::AppShardFrame;
+use quil_types::store::ClockStore;
+use tonic::Status;
+
+struct LocalRoute {
+    core_id: u32,
+    generation: u64,
+    clock_store: Arc<dyn ClockStore>,
+}
+
+/// Resolves public app-shard reads to the worker that currently owns a filter.
+/// The master store is deliberately absent on prover nodes; archives may retain
+/// a store fallback because their local store is authoritative, not a mirror.
+pub(crate) struct AppShardFrameRouter {
+    local: parking_lot::RwLock<HashMap<Vec<u8>, LocalRoute>>,
+    remote: OnceLock<Arc<quil_engine::remote_worker::RemoteWorkerManager>>,
+    archive_store: Option<Arc<dyn ClockStore>>,
+}
+
+impl AppShardFrameRouter {
+    pub(crate) fn new(archive_store: Option<Arc<dyn ClockStore>>) -> Self {
+        Self {
+            local: parking_lot::RwLock::new(HashMap::new()),
+            remote: OnceLock::new(),
+            archive_store,
+        }
+    }
+
+    pub(crate) fn set_remote(&self, manager: Arc<quil_engine::remote_worker::RemoteWorkerManager>) {
+        let _ = self.remote.set(manager);
+    }
+
+    pub(crate) fn register_local(
+        &self,
+        core_id: u32,
+        generation: u64,
+        filter: Vec<u8>,
+        clock_store: Arc<dyn ClockStore>,
+    ) {
+        self.local.write().insert(
+            filter,
+            LocalRoute {
+                core_id,
+                generation,
+                clock_store,
+            },
+        );
+    }
+
+    /// Remove a route only if the deactivation belongs to the same engine
+    /// generation. A cancelled engine can report deactivation after its
+    /// replacement has already activated.
+    pub(crate) fn unregister_local(&self, core_id: u32, generation: u64, filter: &[u8]) -> bool {
+        let mut routes = self.local.write();
+        if routes
+            .get(filter)
+            .is_some_and(|route| route.core_id == core_id && route.generation == generation)
+        {
+            routes.remove(filter);
+            true
+        } else {
+            false
+        }
+    }
+
+    async fn read_store(
+        clock_store: Arc<dyn ClockStore>,
+        filter: Vec<u8>,
+        frame_number: u64,
+    ) -> Result<Option<AppShardFrame>, Status> {
+        tokio::task::spawn_blocking(move || {
+            let result = if frame_number == 0 {
+                clock_store.get_latest_shard_clock_frame(&filter)
+            } else {
+                clock_store.get_shard_clock_frame(&filter, frame_number, false)
+            };
+            match result {
+                Ok(frame) => Ok(Some(frame)),
+                Err(QuilError::NotFound(_)) => Ok(None),
+                Err(e) => Err(Status::internal(format!(
+                    "worker app-shard frame read failed: {e}"
+                ))),
+            }
+        })
+        .await
+        .map_err(|e| Status::internal(format!("worker frame read task failed: {e}")))?
+    }
+}
+
+#[tonic::async_trait]
+impl AppShardFrameProvider for AppShardFrameRouter {
+    async fn get_app_shard_frame(
+        &self,
+        filter: Vec<u8>,
+        frame_number: u64,
+    ) -> Result<Option<AppShardFrame>, Status> {
+        let local_store = self
+            .local
+            .read()
+            .get(&filter)
+            .map(|route| route.clock_store.clone());
+        if let Some(clock_store) = local_store {
+            match Self::read_store(clock_store, filter.clone(), frame_number).await {
+                Ok(Some(frame)) => return Ok(Some(frame)),
+                Ok(None) => {}
+                Err(status) => return Err(status),
+            }
+        }
+
+        if let Some(remote) = self.remote.get() {
+            match remote.get_app_shard_frame(&filter, frame_number).await {
+                Ok(Some(frame)) => return Ok(Some(frame)),
+                Ok(None) => {}
+                Err(status) => return Err(status),
+            }
+        }
+
+        if let Some(clock_store) = self.archive_store.clone() {
+            return Self::read_store(clock_store, filter, frame_number).await;
+        }
+
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quil_store::testing::InMemoryClockStore;
+
+    fn store_with_frame(filter: &[u8], frame_number: u64) -> Arc<InMemoryClockStore> {
+        let store = Arc::new(InMemoryClockStore::new());
+        let mut header = quil_types::proto::global::FrameHeader::default();
+        header.address = filter.to_vec();
+        header.frame_number = frame_number;
+        let frame = AppShardFrame {
+            header: Some(header),
+            requests: Vec::new(),
+            ..Default::default()
+        };
+        let selector = vec![frame_number as u8; 32];
+        let txn = store.new_transaction(false).unwrap();
+        store
+            .stage_shard_clock_frame(&selector, &frame, txn.as_ref())
+            .unwrap();
+        store
+            .commit_shard_clock_frame(filter, frame_number, &selector, txn.as_ref(), false)
+            .unwrap();
+        txn.commit().unwrap();
+        store
+    }
+
+    #[tokio::test]
+    async fn serves_latest_and_numbered_directly_from_worker_store() {
+        let filter = b"worker-shard";
+        let worker_store = store_with_frame(filter, 17);
+        let master_store = Arc::new(InMemoryClockStore::new());
+        let router = AppShardFrameRouter::new(None);
+        router.register_local(1, 1, filter.to_vec(), worker_store);
+
+        let latest = router
+            .get_app_shard_frame(filter.to_vec(), 0)
+            .await
+            .unwrap()
+            .unwrap();
+        let numbered = router
+            .get_app_shard_frame(filter.to_vec(), 17)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(latest.header.unwrap().frame_number, 17);
+        assert_eq!(numbered.header.unwrap().frame_number, 17);
+        assert!(matches!(
+            master_store.get_latest_shard_clock_frame(filter),
+            Err(QuilError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn stale_deactivation_cannot_remove_replacement_route() {
+        let filter = b"worker-shard";
+        let router = AppShardFrameRouter::new(None);
+        router.register_local(1, 1, filter.to_vec(), store_with_frame(filter, 3));
+        router.register_local(1, 2, filter.to_vec(), store_with_frame(filter, 4));
+
+        assert!(!router.unregister_local(1, 1, filter));
+        let frame = router
+            .get_app_shard_frame(filter.to_vec(), 0)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(frame.header.unwrap().frame_number, 4);
+
+        assert!(router.unregister_local(1, 2, filter));
+        assert!(router
+            .get_app_shard_frame(filter.to_vec(), 0)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn archive_store_is_an_explicit_fallback() {
+        let filter = b"archived-shard";
+        let archive_store = store_with_frame(filter, 8);
+        let router = AppShardFrameRouter::new(Some(archive_store));
+
+        let frame = router
+            .get_app_shard_frame(filter.to_vec(), 0)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(frame.header.unwrap().frame_number, 8);
+    }
+
+    #[tokio::test]
+    async fn archive_store_fills_an_active_worker_history_miss() {
+        let filter = b"archived-shard";
+        let archive_store = store_with_frame(filter, 8);
+        let router = AppShardFrameRouter::new(Some(archive_store));
+        router.register_local(1, 1, filter.to_vec(), Arc::new(InMemoryClockStore::new()));
+
+        let frame = router
+            .get_app_shard_frame(filter.to_vec(), 8)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(frame.header.unwrap().frame_number, 8);
+    }
+
+    #[tokio::test]
+    async fn archive_store_fills_an_unassigned_remote_miss() {
+        let filter = b"archived-shard";
+        let archive_store = store_with_frame(filter, 8);
+        let router = AppShardFrameRouter::new(Some(archive_store));
+        router.set_remote(Arc::new(
+            quil_engine::remote_worker::RemoteWorkerManager::new(
+                Vec::new(),
+                "http://master:8340".into(),
+                None,
+            ),
+        ));
+
+        let frame = router
+            .get_app_shard_frame(filter.to_vec(), 8)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(frame.header.unwrap().frame_number, 8);
+    }
+}

--- a/crates/quil-node/src/master_node/grpc.rs
+++ b/crates/quil-node/src/master_node/grpc.rs
@@ -22,6 +22,8 @@ pub(crate) struct GrpcArgs {
     pub signer_registry: Arc<quil_p2p::SignerRegistry>,
     pub prover_pipeline: Arc<quil_engine::prover_pipeline::ProverPipeline>,
     pub worker_manager: Arc<dyn quil_engine::worker::WorkerManager>,
+    pub app_shard_frame_provider:
+        Arc<dyn quil_rpc::stub_services::AppShardFrameProvider>,
     pub inclusion_prover: Arc<dyn quil_types::crypto::InclusionProver>,
     pub peer_id: quil_p2p::PeerId,
     pub p2p_handle: quil_p2p::node::P2PHandle,
@@ -258,6 +260,7 @@ pub(crate) fn spawn_all(
         signer_registry,
         prover_pipeline,
         worker_manager,
+        app_shard_frame_provider,
         inclusion_prover,
         peer_id,
         p2p_handle,
@@ -1162,8 +1165,12 @@ pub(crate) fn spawn_all(
         );
         let app_shard_service = tonic::service::interceptor::InterceptedService::new(
             quil_types::proto::global::app_shard_service_server::AppShardServiceServer::new(
-                quil_rpc::stub_services::AppShardRpcServer::new(clock_store.clone() as Arc<dyn quil_types::store::ClockStore>),
-            ),
+                quil_rpc::stub_services::AppShardRpcServer::with_provider(
+                    app_shard_frame_provider.clone(),
+                ),
+            )
+            .max_decoding_message_size(64 * 1024 * 1024)
+            .max_encoding_message_size(64 * 1024 * 1024),
             quil_rpc::peer_auth_middleware::peer_auth_interceptor,
         );
         let key_registry_service = tonic::service::interceptor::InterceptedService::new(

--- a/crates/quil-node/src/master_node/mod.rs
+++ b/crates/quil-node/src/master_node/mod.rs
@@ -5,6 +5,7 @@ use tracing::{debug, info, warn};
 use quil_lifecycle::{ShutdownReason, Supervisor};
 
 pub(crate) mod allocator_and_lifecycle;
+pub(crate) mod app_shard_router;
 pub(crate) mod archive_sync;
 pub(crate) mod engines;
 pub(crate) mod frame_pipeline;
@@ -251,6 +252,11 @@ pub(crate) async fn start(
     let shard_engines: Arc<parking_lot::RwLock<
         std::collections::HashMap<Vec<u8>, quil_engine::app_engine::AppEngineHandle>,
     >> = Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
+    let app_shard_frame_router = Arc::new(app_shard_router::AppShardFrameRouter::new(
+        archive_mode.then(|| {
+            clock_store.clone() as Arc<dyn quil_types::store::ClockStore>
+        }),
+    ));
     // SignerRegistry — populated from inbound KeyRegistry broadcasts
     // on GLOBAL_PEER_INFO. Consumed by consensus message verification
     // (BLS signatures from peers whose identity↔prover binding we've
@@ -357,6 +363,7 @@ pub(crate) async fn start(
             prover_address,
             bls_pubkey: bls_pubkey.clone(),
             shard_engines: shard_engines.clone(),
+            app_shard_frame_router: app_shard_frame_router.clone(),
             remote_worker_manager_for_halt: remote_worker_manager_for_halt.clone(),
             pi_worker_manager: pi_worker_manager.clone(),
             prover_message_transport: prover_message_transport_cell.clone(),
@@ -1033,6 +1040,7 @@ pub(crate) async fn start(
         signer_registry: signer_registry.clone(),
         prover_pipeline: prover_pipeline.clone(),
         worker_manager: worker_manager.clone(),
+        app_shard_frame_provider: app_shard_frame_router.clone(),
         inclusion_prover: inclusion_prover.clone(),
         peer_id,
         p2p_handle: p2p_handle.clone(),

--- a/crates/quil-node/src/master_node/worker_manager.rs
+++ b/crates/quil-node/src/master_node/worker_manager.rs
@@ -4,9 +4,6 @@ use tracing::{debug, info, warn};
 
 // Import KeyManager trait for get_signer
 use quil_keys::KeyManager as _;
-// ClockStore trait — mirror worker-finalized app-shard frames into the master store.
-use quil_types::store::ClockStore as _;
-
 use quil_lifecycle::Supervisor;
 
 pub(crate) struct WorkerManagerArgs {
@@ -29,6 +26,7 @@ pub(crate) struct WorkerManagerArgs {
     pub shard_engines: Arc<parking_lot::RwLock<
         std::collections::HashMap<Vec<u8>, quil_engine::app_engine::AppEngineHandle>,
     >>,
+    pub app_shard_frame_router: Arc<super::app_shard_router::AppShardFrameRouter>,
     pub remote_worker_manager_for_halt:
         Arc<std::sync::OnceLock<Arc<quil_engine::remote_worker::RemoteWorkerManager>>>,
     pub pi_worker_manager: Arc<std::sync::OnceLock<Arc<dyn quil_engine::worker::WorkerManager>>>,
@@ -48,7 +46,6 @@ pub(crate) struct WorkerManagerArgs {
     >,
     pub spawner: quil_lifecycle::DetachedSpawner<anyhow::Error>,
 }
-
 pub(crate) fn init(
     sup: &mut Supervisor<anyhow::Error>,
     args: WorkerManagerArgs,
@@ -71,6 +68,7 @@ pub(crate) fn init(
         prover_address,
         bls_pubkey,
         shard_engines,
+        app_shard_frame_router,
         remote_worker_manager_for_halt,
         pi_worker_manager,
         prover_message_transport,
@@ -132,6 +130,7 @@ pub(crate) fn init(
             // Publish to the halt broadcaster spawned above so it can
             // SetHalted across standalone workers when coverage halts.
             let _ = remote_worker_manager_for_halt.set(remote_mgr.clone());
+            app_shard_frame_router.set_remote(remote_mgr.clone());
             // Establish (and maintain) the gRPC channels to the remote workers.
             // `connect_all` was previously never called — cluster workers
             // registered but the master never connected, so the Respawn stayed
@@ -387,11 +386,7 @@ pub(crate) fn init(
                 let drain_halt = halt_state.clone();
                 let drain_spawner = spawner.clone();
                 let drain_transport_cell = prover_message_transport.clone();
-                // Master clock store — worker-finalized app-shard frames are mirrored
-                // here so `AppShardService` (and any master-side reader) can serve
-                // them. Workers commit into their OWN per-worker store, which the
-                // master-store-backed service otherwise can't see.
-                let drain_clock_store = clock_store.clone();
+                let drain_app_shard_router = app_shard_frame_router.clone();
                 sup.run_until_cancelled("worker-master-drain", move |_token| async move {
                     loop {
                         let Some(event) = master_rx.recv().await else { break };
@@ -531,40 +526,6 @@ pub(crate) fn init(
                                         if drain_halt.any_halted() {
                                             continue;
                                         }
-                                        // Mirror the finalized frame into the MASTER clock store
-                                        // so `AppShardService::get_app_shard_frame` (which reads
-                                        // the master store) serves real frames — the worker
-                                        // commits it only into its OWN per-worker store. Mirrors
-                                        // the engine's own commit (stage by selector =
-                                        // poseidon(header.output), so `get_latest_shard_clock_frame`
-                                        // resolves). Best-effort; failure never blocks the publish.
-                                        if let Ok(frame) = <quil_types::proto::global::AppShardFrame as prost::Message>::decode(&frame_data[..]) {
-                                            if let Some(header) = frame.header.as_ref() {
-                                                let selector = quil_crypto::poseidon::hash_bytes_to_32(&header.output)
-                                                    .map(|h| h.to_vec())
-                                                    .unwrap_or_default();
-                                                let frame_number = header.frame_number;
-                                                if let Ok(txn) = drain_clock_store.new_transaction(false) {
-                                                    match drain_clock_store.stage_shard_clock_frame(&selector, &frame, txn.as_ref()) {
-                                                        Ok(()) => { let _ = txn.commit(); }
-                                                        Err(e) => warn!(core_id, filter = %hex::encode(&filter), error = %e, "mirror app-shard frame to master store failed"),
-                                                    }
-                                                }
-                                                // Commit the latest-index pointer too: staging alone
-                                                // writes the staged key only, so `get_latest_shard_clock_frame`
-                                                // (which reads the canonical key via the latest index) would
-                                                // NOT resolve to this frame — the master's serving head +
-                                                // co-located proposer would stay stuck on the prior frame and
-                                                // re-propose it. Monotonic (clock.rs:1152), so safe to re-run.
-                                                if let Ok(txn) = drain_clock_store.new_transaction(false) {
-                                                    if let Err(e) = drain_clock_store.commit_shard_clock_frame(&filter, frame_number, &selector, txn.as_ref(), false) {
-                                                        warn!(core_id, filter = %hex::encode(&filter), error = %e, "commit mirrored app-shard frame head failed");
-                                                    } else {
-                                                        let _ = txn.commit();
-                                                    }
-                                                }
-                                            }
-                                        }
                                         let p2p = drain_p2p.clone();
                                         drain_spawner.detach("shard-full-frame-publish", async move {
                                             if let Err(e) = p2p
@@ -644,7 +605,13 @@ pub(crate) fn init(
                                             Ok(())
                                         });
                                     }
-                                    WorkerToMaster::ShardActivated { core_id, filter, handle } => {
+                                    WorkerToMaster::ShardActivated {
+                                        core_id,
+                                        generation,
+                                        filter,
+                                        handle,
+                                        clock_store,
+                                    } => {
                                         // Push the current halt state to the
                                         // freshly-activated engine before
                                         // registering it. Without this the
@@ -660,44 +627,61 @@ pub(crate) fn init(
                                             let mut map = drain_shard_engines.write();
                                             map.insert(filter.clone(), handle);
                                         }
+                                        drain_app_shard_router.register_local(
+                                            core_id,
+                                            generation,
+                                            filter.clone(),
+                                            clock_store,
+                                        );
                                         // Subscribe BlossomSub to the four
                                         // per-shard bitmasks. Without these
                                         // subscriptions our mesh peers won't
                                         // forward shard traffic to us, so
                                         // peer votes / proposals / frames /
                                         // dispatches never reach the engine.
-                                        let p2p = drain_p2p.clone();
-                                        let filter_for_sub = filter.clone();
-                                        drain_spawner.detach("shard-subscribe", async move {
-                                            p2p.subscribe(quil_engine::bitmasks::shard_frame_bitmask(&filter_for_sub)).await;
-                                            p2p.subscribe(quil_engine::bitmasks::shard_consensus_bitmask(&filter_for_sub)).await;
-                                            p2p.subscribe(quil_engine::bitmasks::shard_prover_bitmask(&filter_for_sub)).await;
-                                            p2p.subscribe(quil_engine::bitmasks::shard_dispatch_bitmask(&filter_for_sub)).await;
-                                            // (P3) Subscribe the shard's commonware-simplex topic so
-                                            // committee peers' votes/certs/blocks reach this engine.
-                                            p2p.subscribe(quil_engine::bitmasks::shard_cw_bitmask(&filter_for_sub)).await;
-                                            Ok(())
-                                        });
+                                        // Keep subscription transitions ordered with activation
+                                        // events. Detached subscribe/unsubscribe tasks can land in
+                                        // reverse order during a fast respawn.
+                                        drain_p2p.subscribe(quil_engine::bitmasks::shard_frame_bitmask(&filter)).await;
+                                        drain_p2p.subscribe(quil_engine::bitmasks::shard_consensus_bitmask(&filter)).await;
+                                        drain_p2p.subscribe(quil_engine::bitmasks::shard_prover_bitmask(&filter)).await;
+                                        drain_p2p.subscribe(quil_engine::bitmasks::shard_dispatch_bitmask(&filter)).await;
+                                        // (P3) Subscribe the shard's commonware-simplex topic so
+                                        // committee peers' votes/certs/blocks reach this engine.
+                                        drain_p2p.subscribe(quil_engine::bitmasks::shard_cw_bitmask(&filter)).await;
                                         info!(
                                             core_id,
                                             filter = %hex::encode(&filter),
                                             "registered shard engine + subscribed per-shard bitmasks"
                                         );
                                     }
-                                    WorkerToMaster::ShardDeactivated { core_id, filter } => {
+                                    WorkerToMaster::ShardDeactivated {
+                                        core_id,
+                                        generation,
+                                        filter,
+                                    } => {
+                                        if !drain_app_shard_router.unregister_local(
+                                            core_id,
+                                            generation,
+                                            &filter,
+                                        ) {
+                                            debug!(
+                                                core_id,
+                                                generation,
+                                                filter = %hex::encode(&filter),
+                                                "ignored stale shard deactivation"
+                                            );
+                                            continue;
+                                        }
                                         {
                                             let mut map = drain_shard_engines.write();
                                             map.remove(&filter);
                                         }
-                                        let p2p = drain_p2p.clone();
-                                        let filter_for_sub = filter.clone();
-                                        drain_spawner.detach("shard-unsubscribe", async move {
-                                            p2p.unsubscribe(quil_engine::bitmasks::shard_frame_bitmask(&filter_for_sub)).await;
-                                            p2p.unsubscribe(quil_engine::bitmasks::shard_consensus_bitmask(&filter_for_sub)).await;
-                                            p2p.unsubscribe(quil_engine::bitmasks::shard_prover_bitmask(&filter_for_sub)).await;
-                                            p2p.unsubscribe(quil_engine::bitmasks::shard_dispatch_bitmask(&filter_for_sub)).await;
-                                            Ok(())
-                                        });
+                                        drain_p2p.unsubscribe(quil_engine::bitmasks::shard_frame_bitmask(&filter)).await;
+                                        drain_p2p.unsubscribe(quil_engine::bitmasks::shard_consensus_bitmask(&filter)).await;
+                                        drain_p2p.unsubscribe(quil_engine::bitmasks::shard_prover_bitmask(&filter)).await;
+                                        drain_p2p.unsubscribe(quil_engine::bitmasks::shard_dispatch_bitmask(&filter)).await;
+                                        drain_p2p.unsubscribe(quil_engine::bitmasks::shard_cw_bitmask(&filter)).await;
                                         info!(
                                             core_id,
                                             filter = %hex::encode(&filter),

--- a/crates/quil-rpc/src/stub_services.rs
+++ b/crates/quil-rpc/src/stub_services.rs
@@ -24,21 +24,71 @@ use quil_types::proto::global::{
 use quil_types::proto::node::{
     self, connectivity_service_server::ConnectivityService,
 };
+use quil_types::error::QuilError;
 use quil_types::store::ClockStore;
 
 // =====================================================================
 // AppShardService — shard frame/proposal reads
 // =====================================================================
 
-/// Serves the latest per-filter app-shard frames out of the local
-/// clock store. Backed by the same `ClockStore` the engine writes to.
-pub struct AppShardRpcServer {
+/// Resolves app-shard frames from the worker that currently owns a filter.
+///
+/// Archive nodes use a store-backed provider instead because their local
+/// clock store is the durable source of truth rather than a worker mirror.
+#[tonic::async_trait]
+pub trait AppShardFrameProvider: Send + Sync {
+    async fn get_app_shard_frame(
+        &self,
+        filter: Vec<u8>,
+        frame_number: u64,
+    ) -> Result<Option<global::AppShardFrame>, Status>;
+}
+
+struct ClockStoreAppShardFrameProvider {
     clock_store: Arc<dyn ClockStore>,
 }
 
+#[tonic::async_trait]
+impl AppShardFrameProvider for ClockStoreAppShardFrameProvider {
+    async fn get_app_shard_frame(
+        &self,
+        filter: Vec<u8>,
+        frame_number: u64,
+    ) -> Result<Option<global::AppShardFrame>, Status> {
+        let clock_store = self.clock_store.clone();
+        tokio::task::spawn_blocking(move || {
+            let result = if frame_number == 0 {
+                clock_store.get_latest_shard_clock_frame(&filter)
+            } else {
+                clock_store.get_shard_clock_frame(&filter, frame_number, false)
+            };
+            match result {
+                Ok(frame) => Ok(Some(frame)),
+                Err(QuilError::NotFound(_)) => Ok(None),
+                Err(e) => Err(Status::internal(format!(
+                    "app-shard frame store read failed: {e}"
+                ))),
+            }
+        })
+        .await
+        .map_err(|e| Status::internal(format!("app-shard frame read task failed: {e}")))?
+    }
+}
+
+/// Public AppShardService facade. The provider is worker-routed on prover
+/// nodes and store-backed on archives.
+pub struct AppShardRpcServer {
+    provider: Arc<dyn AppShardFrameProvider>,
+}
+
 impl AppShardRpcServer {
+    /// Construct the archive/store-backed variant.
     pub fn new(clock_store: Arc<dyn ClockStore>) -> Self {
-        Self { clock_store }
+        Self::with_provider(Arc::new(ClockStoreAppShardFrameProvider { clock_store }))
+    }
+
+    pub fn with_provider(provider: Arc<dyn AppShardFrameProvider>) -> Self {
+        Self { provider }
     }
 }
 
@@ -52,15 +102,10 @@ impl AppShardService for AppShardRpcServer {
         if req.filter.is_empty() {
             return Err(Status::invalid_argument("filter required"));
         }
-        let frame = if req.frame_number == 0 {
-            self.clock_store
-                .get_latest_shard_clock_frame(&req.filter)
-                .ok()
-        } else {
-            self.clock_store
-                .get_shard_clock_frame(&req.filter, req.frame_number, false)
-                .ok()
-        };
+        let frame = self
+            .provider
+            .get_app_shard_frame(req.filter, req.frame_number)
+            .await?;
         Ok(Response::new(global::AppShardFrameResponse {
             frame,
             proof: Vec::new(),
@@ -274,5 +319,117 @@ impl ConnectivityService for ConnectivityRpcServer {
             success: true,
             error_message: String::new(),
         }))
+    }
+}
+
+#[cfg(test)]
+mod app_shard_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct RecordingProvider {
+        calls: Mutex<Vec<(Vec<u8>, u64)>>,
+        fail: bool,
+    }
+
+    #[tonic::async_trait]
+    impl AppShardFrameProvider for RecordingProvider {
+        async fn get_app_shard_frame(
+            &self,
+            filter: Vec<u8>,
+            frame_number: u64,
+        ) -> Result<Option<global::AppShardFrame>, Status> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((filter.clone(), frame_number));
+            if self.fail {
+                return Err(Status::unavailable("worker offline"));
+            }
+            let mut header = global::FrameHeader::default();
+            header.address = filter;
+            header.frame_number = if frame_number == 0 { 22 } else { frame_number };
+            Ok(Some(global::AppShardFrame {
+                header: Some(header),
+                requests: Vec::new(),
+                ..Default::default()
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn latest_and_numbered_reads_are_forwarded_unchanged() {
+        let provider = Arc::new(RecordingProvider {
+            calls: Mutex::new(Vec::new()),
+            fail: false,
+        });
+        let server = AppShardRpcServer::with_provider(provider.clone());
+
+        let latest = server
+            .get_app_shard_frame(Request::new(global::GetAppShardFrameRequest {
+                filter: b"shard-a".to_vec(),
+                frame_number: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .frame
+            .unwrap();
+        let numbered = server
+            .get_app_shard_frame(Request::new(global::GetAppShardFrameRequest {
+                filter: b"shard-a".to_vec(),
+                frame_number: 19,
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .frame
+            .unwrap();
+
+        assert_eq!(latest.header.unwrap().frame_number, 22);
+        assert_eq!(numbered.header.unwrap().frame_number, 19);
+        assert_eq!(
+            *provider.calls.lock().unwrap(),
+            vec![(b"shard-a".to_vec(), 0), (b"shard-a".to_vec(), 19)]
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_filter_is_rejected_before_provider_call() {
+        let provider = Arc::new(RecordingProvider {
+            calls: Mutex::new(Vec::new()),
+            fail: false,
+        });
+        let server = AppShardRpcServer::with_provider(provider.clone());
+
+        let status = server
+            .get_app_shard_frame(Request::new(global::GetAppShardFrameRequest {
+                filter: Vec::new(),
+                frame_number: 0,
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(provider.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn provider_failures_are_not_flattened_to_missing_frames() {
+        let provider = Arc::new(RecordingProvider {
+            calls: Mutex::new(Vec::new()),
+            fail: true,
+        });
+        let server = AppShardRpcServer::with_provider(provider);
+
+        let status = server
+            .get_app_shard_frame(Request::new(global::GetAppShardFrameRequest {
+                filter: b"shard-a".to_vec(),
+                frame_number: 0,
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::Unavailable);
     }
 }


### PR DESCRIPTION
## Summary

- serve AppShardService reads directly from the active local worker store or proxy them to the acknowledged active remote worker
- remove the master-side FullFrameProduced frame mirror that duplicated worker data and could leave gaps or orphaned frames
- retain authoritative archive-store fallback while preserving worker read and transport errors
- generation-guard local activation, serialize remote reassignment, send idle deallocation commands, and stop superseded app consensus hosts
- raise AppShardService transport limits to 64 MiB and preserve latest versus numbered frame semantics

## Validation

- Docker nextest focused suite: 45 passed, 629 skipped
- Docker cargo check --locked -p quil-node --tests
- Taskfile-equivalent AMD64 production node build
- regression coverage proves public reads succeed with the master store empty, plus archive fallback, reassignment ordering, deallocation, shutdown, error mapping, and responses above 4 MiB

Fixes #588