### PR TITLE
Fix duplicate app shard frame numbers

### DIFF
--- a/crates/quil-cw-consensus/src/adapters.rs
+++ b/crates/quil-cw-consensus/src/adapters.rs
@@ -93,10 +93,18 @@ pub trait GlobalProposer: Send + Sync + 'static {
     /// out and nullifies the view (mirrors the existing leader-can't-build SKIP).
     fn propose(&self, view: u64, parent_digest: Digest) -> Option<(Digest, Vec<u8>)>;
 
-    /// Validate a proposed frame `digest` for `view`. `bytes` is the frame body
-    /// if already delivered (via `FrameSink`), else `None` (not yet arrived →
-    /// return `false` so the view nullifies rather than votes blind).
-    fn verify(&self, view: u64, digest: Digest, bytes: Option<Vec<u8>>) -> bool;
+    /// Validate a proposed frame `digest` for `view` as a child of
+    /// `parent_digest`. `bytes` is the frame body if already delivered (via
+    /// `FrameSink`), else `None` (not yet arrived → return `false` so the view
+    /// nullifies rather than votes blind). Passing the consensus parent lets
+    /// application seams enforce height + parent linkage before voting.
+    fn verify(
+        &self,
+        view: u64,
+        parent_digest: Digest,
+        digest: Digest,
+        bytes: Option<Vec<u8>>,
+    ) -> bool;
 }
 
 /// Ships frame bytes to peers — the `Relay` behind consensus. In the node this
@@ -184,6 +192,7 @@ impl<E: Spawner + Clock + Send + 'static, Pr: GlobalProposer> Automaton
     ) -> oneshot::Receiver<bool> {
         let (tx, rx) = oneshot::channel();
         let view: u64 = context.view().get();
+        let parent = context.parent.1;
         let proposer = self.proposer.clone();
         let store = self.store.clone();
         self.context.child("verify").spawn(move |ctx| async move {
@@ -202,7 +211,7 @@ impl<E: Spawner + Clock + Send + 'static, Pr: GlobalProposer> Automaton
                 bytes = store.get(&payload);
                 waited += 1;
             }
-            let ok = proposer.verify(view, payload, bytes);
+            let ok = proposer.verify(view, parent, payload, bytes);
             let _ = tx.send(ok);
         });
         rx

--- a/crates/quil-cw-consensus/tests/falcon_adapters.rs
+++ b/crates/quil-cw-consensus/tests/falcon_adapters.rs
@@ -50,7 +50,13 @@ impl GlobalProposer for TestProposer {
         let digest = h.finalize();
         Some((digest, digest.as_ref().to_vec()))
     }
-    fn verify(&self, _view: u64, _digest: Sha256Digest, bytes: Option<Vec<u8>>) -> bool {
+    fn verify(
+        &self,
+        _view: u64,
+        _parent_digest: Sha256Digest,
+        _digest: Sha256Digest,
+        bytes: Option<Vec<u8>>,
+    ) -> bool {
         // With a shared store the block is always present; a real verifier runs
         // frame validation here.
         bytes.is_some()

--- a/crates/quil-cw-consensus/tests/falcon_tokio.rs
+++ b/crates/quil-cw-consensus/tests/falcon_tokio.rs
@@ -35,7 +35,13 @@ impl GlobalProposer for TestProposer {
         let digest = h.finalize();
         Some((digest, digest.as_ref().to_vec()))
     }
-    fn verify(&self, _v: u64, _d: Sha256Digest, bytes: Option<Vec<u8>>) -> bool {
+    fn verify(
+        &self,
+        _v: u64,
+        _parent_digest: Sha256Digest,
+        _d: Sha256Digest,
+        bytes: Option<Vec<u8>>,
+    ) -> bool {
         bytes.is_some()
     }
 }

--- a/crates/quil-engine/src/app_engine.rs
+++ b/crates/quil-engine/src/app_engine.rs
@@ -339,7 +339,7 @@ struct AppLeaderProvider {
     /// `requests_root` is computed over these bundles' canonical
     /// encodings, so it is recomputable/verifiable from the frame.
     frame_requests: Arc<std::sync::Mutex<
-        std::collections::HashMap<u64, Vec<quil_types::proto::global::MessageBundle>>,
+        std::collections::HashMap<(u64, u64), Vec<quil_types::proto::global::MessageBundle>>,
     >>,
     /// KV backing the member's persisted PoRep replicas. Present iff this node
     /// participates in storage (built into a `ReplicaStore` in `prove_next_state`
@@ -353,7 +353,8 @@ struct AppLeaderProvider {
     /// `frame_requests`. Under commonware-simplex, votes carry no payload, so this
     /// is a PROPOSER SELF-attestation (single member = the frame's prover), NOT
     /// the legacy multi-member committee attestation assembled from vote openings.
-    frame_attestations: Arc<std::sync::Mutex<std::collections::HashMap<u64, Vec<u8>>>>,
+    frame_attestations:
+        Arc<std::sync::Mutex<std::collections::HashMap<(u64, u64), Vec<u8>>>>,
     /// Order-independent fingerprint of THIS CW instance's committee (the fixed
     /// simplex validator set built at `start_consensus_cw`). The finalization
     /// cert a proposed frame receives is signed by exactly this committee, but
@@ -451,11 +452,7 @@ impl quil_consensus::leader_provider::LeaderProvider<AppShardState> for AppLeade
         &self,
         rank: u64,
         _filter: &[u8],
-        // App shards resolve their parent from the latest shard clock frame
-        // (see below), not from a consensus-passed frame number, so this is
-        // unused here. It exists on the trait for the global engine, which
-        // must build on the exact consensus-chosen parent.
-        _prior_frame_number: u64,
+        prior_frame_number: u64,
         prior_state_id: &Identity,
     ) -> Result<State<AppShardState>> {
         // Coverage halt gate. Mirrors Go's `app_consensus_engine.go`
@@ -584,32 +581,60 @@ impl quil_consensus::leader_provider::LeaderProvider<AppShardState> for AppLeade
                 ));
             }
         }
-        // Get latest shard frame number
-        let prior_frame_number = self.clock_store
-            .get_latest_shard_clock_frame(&self.filter)
-            .ok()
-            .and_then(|f| f.header.as_ref().map(|h| h.frame_number))
-            .unwrap_or(0);
-        let frame_number = prior_frame_number + 1;
+        // Build on the parent selected by Simplex, not whatever frame happens
+        // to be the clock-store head when this callback runs. Simplex may enter
+        // view V+1 as soon as V is certified, before V's finalization callback
+        // has committed/materialized it locally. Re-reading the store in that
+        // window used N-1 as the parent again and produced a second frame N.
+        //
+        // App-shard state roots are the materialized pre-state, so unlike the
+        // global chain we deliberately wait until the selected parent is both
+        // canonical and materialized. A NoVote only nullifies this view; once
+        // the finalization callback catches up, the next view can safely build
+        // N+1 from the exact parent bytes and identity.
+        let materialized = self
+            .shard_mat_frame
+            .load(std::sync::atomic::Ordering::SeqCst);
+        if materialized != prior_frame_number {
+            return Err(QuilError::NoVote(format!(
+                "cannot build on consensus parent {prior_frame_number}: local materialized \
+                 frame is {materialized} — waiting for exact parent state",
+            )));
+        }
 
-        // STRICT GATE (mirrors the global `compute_prover_root`): never produce
-        // frame N until this node has MATERIALIZED the parent N-1. `state_roots`
-        // below reads the committed shard state and MUST equal N-1's — a lagging
-        // proposer would otherwise emit a stale root that voters (fail-closed at
-        // N-1) reject after the fact. Catching up is fine (skip old frames via
-        // shard sync); producing on unapplied state is not. `NoVote` = skip this
-        // round (not `Consensus`, which would kill the event loop); the node
-        // resumes proposing once its materializer reaches N-1.
-        if prior_frame_number > 0 {
-            let materialized =
-                self.shard_mat_frame.load(std::sync::atomic::Ordering::SeqCst);
-            if materialized < prior_frame_number {
+        let (previous_frame_output, previous_timestamp_ms) = if prior_frame_number == 0 {
+            (Vec::new(), None)
+        } else {
+            let prior = self
+                .clock_store
+                .get_shard_clock_frame(&self.filter, prior_frame_number, false)
+                .map_err(|e| {
+                    QuilError::NoVote(format!(
+                        "cannot build on consensus parent {prior_frame_number}: \
+                         canonical frame unavailable ({e})",
+                    ))
+                })?;
+            let header = prior.header.as_ref().ok_or_else(|| {
+                QuilError::NoVote(format!(
+                    "cannot build on consensus parent {prior_frame_number}: frame has no header",
+                ))
+            })?;
+            let local_parent_id = quil_crypto::poseidon::hash_bytes_to_32(&header.output)
+                .map_err(|e| QuilError::Crypto(format!("app parent poseidon: {e}")))?
+                .to_vec();
+            if local_parent_id != *prior_state_id {
                 return Err(QuilError::NoVote(format!(
-                    "cannot produce shard frame {frame_number}: parent {prior_frame_number} \
-                     not materialized (at {materialized}) — catching up",
+                    "cannot build on consensus parent {prior_frame_number}: local identity {} \
+                     differs from selected identity {} — waiting for exact parent",
+                    hex::encode(local_parent_id),
+                    hex::encode(prior_state_id),
                 )));
             }
-        }
+            (header.output.clone(), Some(header.timestamp))
+        };
+        let frame_number = prior_frame_number.checked_add(1).ok_or_else(|| {
+            QuilError::NoVote("cannot produce app frame after u64::MAX parent".into())
+        })?;
 
         // Collect pending messages (raw canonical bytes from the
         // dispatch bitmask), then decode each into a proto MessageBundle.
@@ -639,10 +664,10 @@ impl quil_consensus::leader_provider::LeaderProvider<AppShardState> for AppLeade
         // Stash the bundles so the engine can retrieve them at
         // finalization (to self-materialize + publish the full frame).
         if let Ok(mut map) = self.frame_requests.lock() {
-            map.insert(frame_number, request_bundles);
+            map.insert((frame_number, rank), request_bundles);
             // Bound memory: keep only recent frames.
             let cutoff = frame_number.saturating_sub(64);
-            map.retain(|&fnum, _| fnum >= cutoff);
+            map.retain(|&(fnum, _), _| fnum >= cutoff);
         }
         debug!(
             filter = hex::encode(&self.filter),
@@ -651,15 +676,6 @@ impl quil_consensus::leader_provider::LeaderProvider<AppShardState> for AppLeade
             messages = canonical_requests.len(),
             "producing shard frame"
         );
-
-        // Pull previous frame's full output for `parent` derivation.
-        // Empty for the first frame (genesis); the prover handles that
-        // by emitting a 32-byte zero parent.
-        let previous_frame_output = self.clock_store
-            .get_latest_shard_clock_frame(&self.filter)
-            .ok()
-            .and_then(|f| f.header.as_ref().map(|h| h.output.clone()))
-            .unwrap_or_default();
 
         let difficulty = self.current_difficulty
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -671,11 +687,7 @@ impl quil_consensus::leader_provider::LeaderProvider<AppShardState> for AppLeade
 
         // Compute fee multiplier vote: base from sliding window +
         // traffic adjustment.
-        let previous_timestamp_ms = self.clock_store
-            .get_latest_shard_clock_frame(&self.filter)
-            .ok()
-            .and_then(|f| f.header.as_ref().map(|h| h.timestamp))
-            .unwrap_or(now_ms - 10_000); // assume 10s if no prior frame
+        let previous_timestamp_ms = previous_timestamp_ms.unwrap_or(now_ms - 10_000);
         let fee_multiplier_vote = crate::fees::compute_fee_multiplier_vote(
             self.fee_manager.as_ref(),
             &self.filter,
@@ -823,6 +835,14 @@ impl quil_consensus::leader_provider::LeaderProvider<AppShardState> for AppLeade
             &storage_attestation_root,
             anchor_gfn,
         )?;
+        // The app output is now a compact deterministic digest rather than the
+        // legacy 516-byte VDF output, so FrameProver cannot derive the parent
+        // selector from `previous_frame_output[..516]`. Bind the wire header to
+        // the exact Simplex parent identity directly. Preserve the all-zero
+        // selector for the synthetic frame-0 floor.
+        if prior_frame_number > 0 {
+            header.parent_selector = prior_state_id.clone();
+        }
         if storage_active {
             // PROPOSER SELF-ATTESTATION (CW PoRep port). Legacy Jolteon assembled
             // the committee `StorageAttestation` from every member's per-vote
@@ -920,7 +940,7 @@ impl quil_consensus::leader_provider::LeaderProvider<AppShardState> for AppLeade
                             header.storage_attestation_root = root;
                             if let Ok(mut map) = self.frame_attestations.lock() {
                                 map.insert(
-                                    frame_number,
+                                    (frame_number, rank),
                                     prost::Message::encode_to_vec(&att),
                                 );
                             }
@@ -1141,10 +1161,10 @@ pub(crate) fn cw_app_storage_base(
 ///  - the **re-seed point** (genesis identity — the frame the engine floors at).
 ///    The journal is persistent but `block_meta` (digest→frame-number) is NOT,
 ///    so on restart the journal can restore the engine to a parent whose digest
-///    the freshly-seeded `block_meta` can't resolve — the proposer then defaults
-///    `prior_frame_number` to 0 and `prove_next_state` fails with "frame 0 not
-///    found", so the leader silently nullifies its own view → total production
-///    halt. This happens whenever the committed head MOVES between runs (the
+///    the freshly-seeded `block_meta` can't resolve — the proposer then
+///    nullifies because it cannot prove the selected parent's height, causing a
+///    total production halt. This happens whenever the committed head MOVES
+///    between runs (the
 ///    fresh genesis differs from the journal's floor). Resetting re-floors
 ///    consensus at the current committed head, consistent with `block_meta`.
 ///
@@ -1262,16 +1282,17 @@ pub struct AppConsensusEngine {
     shard_mat_frame: std::sync::Arc<std::sync::atomic::AtomicU64>,
     /// Shared with the leader provider: requests this node collected for
     /// frames it proposed (proto `MessageBundle`s), keyed by frame
-    /// number. Read at finalization to self-materialize + assemble the
-    /// full `AppShardFrame` for publication.
+    /// number and Simplex view/rank. Read at finalization to self-materialize
+    /// and assemble the full `AppShardFrame` for publication.
     frame_requests: Arc<std::sync::Mutex<
-        std::collections::HashMap<u64, Vec<quil_types::proto::global::MessageBundle>>,
+        std::collections::HashMap<(u64, u64), Vec<quil_types::proto::global::MessageBundle>>,
     >>,
     /// Shared with the leader provider (mirrors `frame_requests`): the serialized
     /// proposer self storage-attestation (`StorageAttestation` openings) for each
     /// frame this node proposed. The `AppFrameAssembler` reads it to attach the
     /// openings to the full `AppShardFrame`. See `AppLeaderProvider::frame_attestations`.
-    frame_attestations: Arc<std::sync::Mutex<std::collections::HashMap<u64, Vec<u8>>>>,
+    frame_attestations:
+        Arc<std::sync::Mutex<std::collections::HashMap<(u64, u64), Vec<u8>>>>,
     /// `requests_root` of frames this node FINALIZED through (BLS-verified)
     /// consensus, keyed by frame number. The trust anchor for materializing
     /// a full frame received on the wire as a follower: the received
@@ -1325,9 +1346,11 @@ pub struct AppConsensusEngine {
     /// what lets a shard grow from a 1-member floor committee (formed before the
     /// second prover's deferred activation) to the real N-member committee.
     cw_committee_fp: Option<[u8; 32]>,
-    /// (P3) Self-clone of the inbound message sender, so `on_finalized` (running
-    /// on the simplex thread) can inject `CwFinalizedFrame` into this run loop.
-    self_msg_tx: mpsc::Sender<AppEngineMessage>,
+    /// Lossless, ordered handoff from the dedicated Simplex runtime thread to
+    /// this engine's finalization handler. Finalizations are safety-critical and
+    /// must not compete for capacity with the best-effort inbound message queue.
+    cw_finalized_tx: mpsc::UnboundedSender<(Vec<u8>, Vec<u8>)>,
+    cw_finalized_rx: Option<mpsc::UnboundedReceiver<(Vec<u8>, Vec<u8>)>>,
 
     /// Atomic publish slot for engine sizes. Updated each event-loop
     /// iteration so external memory snapshots can read internal
@@ -1344,6 +1367,7 @@ impl AppConsensusEngine {
         event_tx: mpsc::UnboundedSender<AppEngineEvent>,
     ) -> (Self, AppEngineHandle) {
         let (msg_tx, msg_rx) = mpsc::channel(CONSENSUS_QUEUE_SIZE);
+        let (cw_finalized_tx, cw_finalized_rx) = mpsc::unbounded_channel();
 
         // The shard's app address IS the domain — the same 32-byte value
         // the master assigns as `filter` (Go's `appAddress`). It must NOT
@@ -1419,7 +1443,8 @@ impl AppConsensusEngine {
             app_consensus_cw: deps.app_consensus_cw,
             cw_handle: None,
             cw_committee_fp: None,
-            self_msg_tx: msg_tx,
+            cw_finalized_tx,
+            cw_finalized_rx: Some(cw_finalized_rx),
             sizes,
         };
         (engine, handle)
@@ -1653,6 +1678,10 @@ impl AppConsensusEngine {
         >,
     ) {
         let mut msg_rx = self.msg_rx.take().expect("msg_rx already taken");
+        let mut cw_finalized_rx = self
+            .cw_finalized_rx
+            .take()
+            .expect("cw_finalized_rx already taken");
 
         info!(
             core_id = self.core_id,
@@ -1778,6 +1807,12 @@ impl AppConsensusEngine {
         loop {
             tokio::select! {
                 biased;
+
+                finalized = cw_finalized_rx.recv() => {
+                    if let Some((frame, cert)) = finalized {
+                        self.handle_cw_finalized_frame(&frame, &cert).await;
+                    }
+                }
 
                 // Inbound network messages
                 msg = msg_rx.recv() => {
@@ -2103,29 +2138,31 @@ impl AppConsensusEngine {
             let frame_attestations = self.frame_attestations.clone();
             Arc::new(move |state| {
                 let fnum = state.state.frame_number;
+                let key = (fnum, state.state.rank);
                 let reqs = frame_requests
                     .lock()
                     .ok()
-                    .and_then(|m| m.get(&fnum).cloned())
+                    .and_then(|m| m.get(&key).cloned())
                     .unwrap_or_default();
                 let attestation = frame_attestations
                     .lock()
                     .ok()
-                    .and_then(|m| m.get(&fnum).cloned())
+                    .and_then(|m| m.get(&key).cloned())
                     .unwrap_or_default();
                 Some(crate::cw_app_seams::app_frame_from_state(state, reqs, attestation))
             })
         };
 
         // on_finalized: route the finalized frame back into THIS engine's run
-        // loop (it runs on the simplex thread → `try_send` into `msg_tx`), where
-        // `handle_cw_finalized_frame` materializes it on `&mut self`.
+        // loop over a dedicated unbounded channel. A bounded `try_send` here can
+        // drop the certified parent while Simplex advances to its child, leaving
+        // the worker permanently unable to materialize the selected parent.
         let on_finalized: crate::cw_app_seams::AppFinalizedSink = {
-            let msg_tx = self.self_msg_tx.clone();
+            let finalized_tx = self.cw_finalized_tx.clone();
             Arc::new(move |frame, cert| {
                 let mut buf = Vec::new();
                 if prost::Message::encode(&frame, &mut buf).is_ok() {
-                    let _ = msg_tx.try_send(AppEngineMessage::CwFinalizedFrame { frame: buf, cert });
+                    let _ = finalized_tx.send((buf, cert));
                 }
             })
         };
@@ -2426,22 +2463,137 @@ impl AppConsensusEngine {
         }
         let frame_number = header.frame_number;
 
-        // Persist the finalized frame to the shard clock store so the NEXT
-        // `prove_next_state` (which reads `get_latest_shard_clock_frame`) chains
-        // on it — otherwise the chain stalls re-proposing on genesis. The legacy
-        // path stages in the incorporated hook + commits on QC; the CW path does
-        // both here at finalize (stage then commit, separate txns like legacy).
-        let selector = quil_crypto::poseidon::hash_bytes_to_32(&header.output)
-            .map(|h| h.to_vec())
-            .unwrap_or_default();
-        if let Ok(txn) = self.clock_store.new_transaction(false) {
-            if let Err(e) = self.clock_store.stage_shard_clock_frame(&selector, &frame, txn.as_ref()) {
-                warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw stage shard frame failed");
-            } else {
-                let _ = txn.commit();
+        // Finalization callbacks must be monotonic at the application boundary,
+        // even if the consensus host replays a callback or ever hands us a
+        // conflicting certified block at an already-committed height. The old
+        // path overwrote the canonical `(filter, frame_number)` value, skipped
+        // materialization via the cursor check, and still republished + awarded
+        // coverage. Never replace an existing height with a different identity.
+        // An identical replay may retry materialization after a prior transient
+        // failure, but it is not published or rewarded a second time.
+        let already_committed = match self.clock_store.get_latest_shard_clock_frame(&self.filter) {
+            Ok(latest) => {
+                let Some(latest_header) = latest.header.as_ref() else {
+                    warn!(core_id = self.core_id, "cw finalized frame: canonical head has no header");
+                    return;
+                };
+                if frame_number < latest_header.frame_number {
+                    warn!(
+                        core_id = self.core_id,
+                        frame = frame_number,
+                        canonical = latest_header.frame_number,
+                        "cw finalized frame: stale finalization below canonical head — dropping",
+                    );
+                    return;
+                }
+                if frame_number == latest_header.frame_number {
+                    if latest_header.output != header.output {
+                        warn!(
+                            core_id = self.core_id,
+                            frame = frame_number,
+                            "cw finalized frame: conflicting identity at canonical height — dropping",
+                        );
+                        return;
+                    }
+                    true
+                } else {
+                    let Some(expected_frame_number) =
+                        latest_header.frame_number.checked_add(1)
+                    else {
+                        warn!(core_id = self.core_id, "cw finalized frame: canonical height overflow");
+                        return;
+                    };
+                    if frame_number != expected_frame_number {
+                        warn!(
+                            core_id = self.core_id,
+                            frame = frame_number,
+                            expected = expected_frame_number,
+                            "cw finalized frame: gap above canonical head — dropping",
+                        );
+                        return;
+                    }
+                    let expected_parent = if latest_header.frame_number == 0 {
+                        vec![0u8; 32]
+                    } else {
+                        match quil_crypto::poseidon::hash_bytes_to_32(&latest_header.output) {
+                            Ok(id) => id.to_vec(),
+                            Err(e) => {
+                                warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw finalized frame: canonical parent identity failed");
+                                return;
+                            }
+                        }
+                    };
+                    if header.parent_selector != expected_parent {
+                        warn!(
+                            core_id = self.core_id,
+                            frame = frame_number,
+                            "cw finalized frame: parent selector does not extend canonical head — dropping",
+                        );
+                        return;
+                    }
+                    false
+                }
             }
-        }
-        if let Ok(txn) = self.clock_store.new_transaction(false) {
+            Err(QuilError::NotFound(_)) => {
+                if frame_number != 1 || header.parent_selector != vec![0u8; 32] {
+                    warn!(
+                        core_id = self.core_id,
+                        frame = frame_number,
+                        "cw finalized frame: non-genesis child without canonical parent — dropping",
+                    );
+                    return;
+                }
+                false
+            }
+            Err(e) => {
+                warn!(
+                    core_id = self.core_id,
+                    frame = frame_number,
+                    error = %e,
+                    "cw finalized frame: cannot read canonical head — dropping",
+                );
+                return;
+            }
+        };
+
+        // Persist the finalized frame to the shard clock store so the NEXT
+        // `prove_next_state` can resolve the exact consensus parent. Persistence
+        // is a prerequisite for all downstream effects: never publish or reward
+        // a frame that this worker failed to make durable.
+        if !already_committed {
+            let selector = match quil_crypto::poseidon::hash_bytes_to_32(&header.output) {
+                Ok(h) => h.to_vec(),
+                Err(e) => {
+                    warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw shard frame selector failed");
+                    return;
+                }
+            };
+            let txn = match self.clock_store.new_transaction(false) {
+                Ok(txn) => txn,
+                Err(e) => {
+                    warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw stage shard frame transaction failed");
+                    return;
+                }
+            };
+            if let Err(e) = self
+                .clock_store
+                .stage_shard_clock_frame(&selector, &frame, txn.as_ref())
+            {
+                warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw stage shard frame failed");
+                return;
+            }
+            if let Err(e) = txn.commit() {
+                warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw stage shard frame transaction commit failed");
+                return;
+            }
+
+            let txn = match self.clock_store.new_transaction(false) {
+                Ok(txn) => txn,
+                Err(e) => {
+                    warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw commit shard frame transaction failed");
+                    return;
+                }
+            };
             if let Err(e) = self.clock_store.commit_shard_clock_frame(
                 &self.filter,
                 frame_number,
@@ -2450,8 +2602,11 @@ impl AppConsensusEngine {
                 false,
             ) {
                 warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw commit shard frame failed");
-            } else {
-                let _ = txn.commit();
+                return;
+            }
+            if let Err(e) = txn.commit() {
+                warn!(core_id = self.core_id, frame = frame_number, error = %e, "cw commit shard frame transaction commit failed");
+                return;
             }
         }
 
@@ -2503,6 +2658,13 @@ impl AppConsensusEngine {
                 Err(e) => warn!(core_id = self.core_id, frame = frame_number, error = %e,
                     "cw-finalized materialize failed (cursor held; will retry)"),
             }
+        }
+
+        // An identical callback replay was already published/rewarded when it
+        // first became canonical. It may have retried materialization above, but
+        // must not appear as a second finalized frame to downstream consumers.
+        if already_committed {
+            return;
         }
 
         // Publish the full frame for followers/archives on `shard_frame_bitmask`.
@@ -2816,7 +2978,7 @@ impl AppConsensusEngine {
             .frame_requests
             .lock()
             .ok()
-            .and_then(|mut m| m.remove(&frame_number))
+            .and_then(|mut m| m.remove(&(frame_number, canon.rank)))
         {
             Some(r) => r,
             None => {
@@ -3881,6 +4043,301 @@ fn validate_app_frame_panic_safe(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use quil_consensus::leader_provider::LeaderProvider as _;
+    use quil_types::crypto::Signer as _;
+
+    fn test_shard_frame(
+        filter: &[u8],
+        frame_number: u64,
+        output_byte: u8,
+    ) -> quil_types::proto::global::AppShardFrame {
+        quil_types::proto::global::AppShardFrame {
+            header: Some(quil_types::proto::global::FrameHeader {
+                address: filter.to_vec(),
+                frame_number,
+                output: vec![output_byte; 516],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn commit_test_shard_frame(
+        store: &dyn ClockStore,
+        filter: &[u8],
+        frame_number: u64,
+        output_byte: u8,
+    ) -> Vec<u8> {
+        let frame = test_shard_frame(filter, frame_number, output_byte);
+        let output = &frame.header.as_ref().expect("test frame header").output;
+        let selector = quil_crypto::poseidon::hash_bytes_to_32(output)
+            .expect("test frame output hashes")
+            .to_vec();
+
+        let txn = store.new_transaction(false).expect("stage transaction");
+        store
+            .stage_shard_clock_frame(&selector, &frame, txn.as_ref())
+            .expect("stage test shard frame");
+        txn.commit().expect("commit staged test shard frame");
+
+        let txn = store.new_transaction(false).expect("canonical transaction");
+        store
+            .commit_shard_clock_frame(filter, frame_number, &selector, txn.as_ref(), false)
+            .expect("commit canonical test shard frame");
+        txn.commit().expect("commit test shard head");
+        selector
+    }
+
+    fn test_app_leader_provider(
+        clock_store: Arc<dyn ClockStore>,
+        filter: Vec<u8>,
+        materialized: Arc<std::sync::atomic::AtomicU64>,
+    ) -> AppLeaderProvider {
+        let prover_address = vec![0x33; 32];
+        let prover_public_key = vec![0x44; 897];
+        let registry = Arc::new(crate::test_support::TestProverRegistry::with_prover(
+            quil_types::consensus::ProverInfo {
+                public_key: prover_public_key.clone(),
+                address: prover_address.clone(),
+                status: quil_types::consensus::ProverStatus::Active,
+                kick_frame_number: 0,
+                allocations: Vec::new(),
+                available_storage: 0,
+                seniority: 1,
+                delegate_address: Vec::new(),
+            },
+        ));
+
+        AppLeaderProvider {
+            filter: filter.clone(),
+            clock_store: clock_store.clone(),
+            global_anchor_store: clock_store,
+            frame_prover: Arc::new(quil_crypto::WesolowskiFrameProver::new(2048)),
+            prover_registry: registry,
+            message_collector: Arc::new(MessageCollector::new()),
+            fee_manager: Arc::new(crate::InMemoryDynamicFeeManager::new(32)),
+            local_prover_address: prover_address,
+            local_public_key: prover_public_key.clone(),
+            current_difficulty: Arc::new(std::sync::atomic::AtomicU32::new(1)),
+            reward_greedy: false,
+            hypergraph: None,
+            storage_source_hypergraph: None,
+            execution_engine: None,
+            inclusion_prover: None,
+            app_address: filter,
+            halted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            min_active_provers_for_propose: 1,
+            shard_mat_frame: materialized,
+            frame_requests: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            kv_db: None,
+            frame_attestations: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            instance_committee_fp: AppConsensusEngine::committee_fp(&[prover_public_key]),
+        }
+    }
+
+    /// Regression for #591. Simplex may enter view V+1 with V as its certified
+    /// parent before V's finalization callback has persisted/materialized it.
+    /// The app proposer must not consult the stale store head and emit another
+    /// frame numbered N+1. It waits; after N+1 is applied, the next proposal is
+    /// N+2 and chains to the exact consensus parent identity.
+    #[test]
+    fn app_leader_waits_for_unfinalized_simplex_parent() {
+        let filter = vec![0xAA; 32];
+        let store = Arc::new(quil_store::testing::InMemoryClockStore::new());
+        let materialized = Arc::new(std::sync::atomic::AtomicU64::new(7));
+        commit_test_shard_frame(store.as_ref(), &filter, 7, 0x07);
+        let provider = test_app_leader_provider(
+            store.clone() as Arc<dyn ClockStore>,
+            filter.clone(),
+            materialized.clone(),
+        );
+
+        // Adjacent Simplex view: frame 8 is the certified consensus parent, but
+        // the finalization callback has not advanced the store/materializer yet.
+        let pending_parent_identity = vec![0x88; 32];
+        let err = provider
+            .prove_next_state(9, &filter, 8, &pending_parent_identity)
+            .expect_err("must not reuse frame number 8 while its parent is unapplied");
+        assert!(
+            err.is_no_vote(),
+            "unapplied consensus parent must defer the view: {err}"
+        );
+
+        // Once that exact parent is durable and materialized, production may
+        // advance. Its output hashes to the identity Simplex supplied.
+        let committed_parent_identity = commit_test_shard_frame(store.as_ref(), &filter, 8, 0x08);
+        materialized.store(8, std::sync::atomic::Ordering::SeqCst);
+        let state = provider
+            .prove_next_state(10, &filter, 8, &committed_parent_identity)
+            .expect("proposal resumes after the consensus parent is applied");
+
+        assert_eq!(state.state.frame_number, 9);
+        assert_eq!(state.state.parent_selector, committed_parent_identity);
+        assert_eq!(state.parent_qc_identity, committed_parent_identity);
+    }
+
+    /// A finalized frame has exactly one durable value, one full-frame publish,
+    /// and one reward/coverage emission. Replaying the same finalization or a
+    /// conflicting block at that height must not overwrite or emit again.
+    #[tokio::test]
+    async fn cw_finalization_is_persisted_and_published_once_per_height() {
+        let filter = vec![0xAB; 32];
+        let store = Arc::new(quil_store::testing::InMemoryClockStore::new());
+        let signer = quil_crypto::FalconSigner::generate();
+        let prover_public_key = signer.public_key().to_vec();
+        let prover_address = quil_crypto::poseidon::hash_bytes_to_32(&prover_public_key)
+            .expect("test prover public key hashes")
+            .to_vec();
+        let registry = Arc::new(crate::test_support::TestProverRegistry::with_prover(
+            quil_types::consensus::ProverInfo {
+                public_key: prover_public_key.clone(),
+                address: prover_address.clone(),
+                status: quil_types::consensus::ProverStatus::Active,
+                kick_frame_number: 0,
+                allocations: Vec::new(),
+                available_storage: 0,
+                seniority: 1,
+                delegate_address: Vec::new(),
+            },
+        ));
+        let coverage_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let coverage_count_for_callback = coverage_count.clone();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let deps = AppEngineDeps {
+            clock_store: store.clone() as Arc<dyn ClockStore>,
+            global_anchor_store: None,
+            prover_registry: registry,
+            frame_prover: Arc::new(quil_crypto::WesolowskiFrameProver::new(2048)),
+            message_collector: Arc::new(MessageCollector::new()),
+            fee_manager: Arc::new(crate::InMemoryDynamicFeeManager::new(32)),
+            local_prover_address: prover_address,
+            local_bls_pubkey: prover_public_key,
+            bls_signer: Box::new(signer),
+            reward_greedy: false,
+            min_active_provers_for_propose: 1,
+            coverage_publish: Some(Arc::new(move |_| {
+                coverage_count_for_callback.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            })),
+            hypergraph: None,
+            storage_source_hypergraph: None,
+            execution_engine: None,
+            inclusion_prover: None,
+            kv_db: None,
+            app_consensus_cw: true,
+            db_config: quil_config::DbConfig::default(),
+        };
+        let (mut engine, _handle) = AppConsensusEngine::new(1, filter.clone(), deps, event_tx);
+
+        // Canonical parent N is durable. The incoming N+1 frame must link to
+        // that exact identity; this also exercises the finalizer's no-gap and
+        // parent-selector guards rather than bypassing them with an empty store.
+        let parent_identity = commit_test_shard_frame(store.as_ref(), &filter, 7, 0x07);
+
+        let mut gap = test_shard_frame(&filter, 9, 0x09);
+        gap.header.as_mut().expect("gap frame header").parent_selector = parent_identity.clone();
+        engine
+            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&gap), &[])
+            .await;
+        assert!(event_rx.try_recv().is_err(), "gap finalization must not publish");
+        assert_eq!(coverage_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(
+            store
+                .get_latest_shard_clock_frame(&filter)
+                .expect("gap must leave parent canonical")
+                .header
+                .expect("canonical parent header")
+                .frame_number,
+            7,
+            "finalizer must not skip a canonical height"
+        );
+
+        let mut wrong_parent = test_shard_frame(&filter, 8, 0x18);
+        wrong_parent.header.as_mut().expect("wrong-parent frame header").parent_selector =
+            vec![0xFF; 32];
+        engine
+            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&wrong_parent), &[])
+            .await;
+        assert!(
+            event_rx.try_recv().is_err(),
+            "wrong-parent finalization must not publish"
+        );
+        assert_eq!(coverage_count.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(
+            store
+                .get_latest_shard_clock_frame(&filter)
+                .expect("wrong parent must leave canonical head unchanged")
+                .header
+                .expect("canonical parent header")
+                .frame_number,
+            7
+        );
+
+        let mut frame = test_shard_frame(&filter, 8, 0x08);
+        frame.header.as_mut().expect("frame header").parent_selector = parent_identity;
+        let encoded = prost::Message::encode_to_vec(&frame);
+        engine.handle_cw_finalized_frame(&encoded, &[]).await;
+
+        let first_events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+        assert_eq!(
+            first_events
+                .iter()
+                .filter(|e| matches!(e, AppEngineEvent::FullFrameProduced { .. }))
+                .count(),
+            1,
+            "first finalization publishes one full frame"
+        );
+        assert_eq!(
+            first_events
+                .iter()
+                .filter(|e| matches!(e, AppEngineEvent::ShardFrameFinalized { .. }))
+                .count(),
+            1,
+            "first finalization emits one rewardable header"
+        );
+        assert_eq!(coverage_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(
+            store
+                .get_latest_shard_clock_frame(&filter)
+                .expect("first finalization persisted")
+                .header
+                .expect("persisted frame header")
+                .output,
+            vec![0x08; 516]
+        );
+
+        engine.handle_cw_finalized_frame(&encoded, &[]).await;
+        assert!(
+            event_rx.try_recv().is_err(),
+            "identical finalization replay must not republish"
+        );
+        assert_eq!(
+            coverage_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "identical finalization replay must not earn coverage twice"
+        );
+
+        let mut conflicting = frame;
+        conflicting.header.as_mut().expect("conflicting frame header").output = vec![0xF8; 516];
+        engine
+            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&conflicting), &[])
+            .await;
+        assert!(
+            event_rx.try_recv().is_err(),
+            "conflicting same-height finalization must not publish"
+        );
+        assert_eq!(coverage_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(
+            store
+                .get_latest_shard_clock_frame(&filter)
+                .expect("canonical head remains readable")
+                .header
+                .expect("canonical head has a header")
+                .output,
+            vec![0x08; 516],
+            "conflicting same-height finalization must not overwrite canonical data"
+        );
+    }
 
     /// Go parity (`app_consensus_engine.go:718`): core 0 → `db.path`; worker
     /// core N → `worker_paths[N-1]` else `worker_path_prefix` (`%d`→N); empty

--- a/crates/quil-engine/src/cw_app_seams.rs
+++ b/crates/quil-engine/src/cw_app_seams.rs
@@ -64,7 +64,7 @@ pub type AppFinalizedSink = Arc<dyn Fn(AppShardFrame, Vec<u8>) + Send + Sync>;
 /// require one — so `public_key_signature_bls48581` is left `None`.
 ///
 /// This is the pure core of the engine-supplied `AppFrameAssembler`: the engine's
-/// closure reads `frame_requests[state.frame_number]` and calls this.
+/// closure reads `frame_requests[(state.frame_number, state.rank)]` and calls this.
 pub fn app_frame_from_state(
     state: &State<AppShardState>,
     requests: Vec<quil_types::proto::global::MessageBundle>,
@@ -121,6 +121,30 @@ fn encode_app_frame(frame: &AppShardFrame) -> Vec<u8> {
 
 fn decode_app_frame(bytes: &[u8]) -> Option<AppShardFrame> {
     <AppShardFrame as prost::Message>::decode(bytes).ok()
+}
+
+/// Bind an app block's wire header to the Simplex proposal context before an
+/// honest replica votes. Header validation alone cannot see the consensus
+/// parent, so this link check lives at the seam where both are available.
+fn app_header_extends_simplex_parent(
+    header: &quil_types::proto::global::FrameHeader,
+    filter: &[u8],
+    view: u64,
+    parent_frame_number: u64,
+    parent_digest: &Digest,
+) -> bool {
+    let Some(expected_frame_number) = parent_frame_number.checked_add(1) else {
+        return false;
+    };
+    let expected_parent = if parent_frame_number == 0 {
+        vec![0u8; 32]
+    } else {
+        digest_to_identity(parent_digest).to_vec()
+    };
+    header.address == filter
+        && header.rank == view
+        && header.frame_number == expected_frame_number
+        && header.parent_selector == expected_parent
 }
 
 // ---------------------------------------------------------------------------
@@ -187,16 +211,27 @@ impl AppSeamProposer {
 impl GlobalProposer for AppSeamProposer {
     fn propose(&self, view: u64, parent_digest: Digest) -> Option<(Digest, Vec<u8>)> {
         let prior_state_id: Vec<u8> = digest_to_identity(&parent_digest).to_vec();
-        let prior_frame_number = self
+        let prior_frame_number = match self
             .block_meta
             .lock()
             .unwrap()
             .get(&parent_digest)
             .copied()
-            .unwrap_or(0);
+        {
+            Some(frame_number) => frame_number,
+            None => {
+                tracing::warn!(
+                    view,
+                    parent = %hex::encode(&prior_state_id),
+                    "cw app propose: consensus parent metadata unavailable — nullify",
+                );
+                return None;
+            }
+        };
 
-        // App shards resolve their parent from the shard clock store internally,
-        // so `prior_frame_number` is advisory; `prior_state_id` is the identity.
+        // Both values come from the Simplex-selected parent. The leader provider
+        // resolves and validates that exact canonical/materialized frame rather
+        // than substituting its local latest head.
         let state = self
             .leader_provider
             .prove_next_state(view, &self.filter, prior_frame_number, &prior_state_id)
@@ -212,7 +247,13 @@ impl GlobalProposer for AppSeamProposer {
         Some((digest, bytes))
     }
 
-    fn verify(&self, _view: u64, digest: Digest, bytes: Option<Vec<u8>>) -> bool {
+    fn verify(
+        &self,
+        view: u64,
+        parent_digest: Digest,
+        digest: Digest,
+        bytes: Option<Vec<u8>>,
+    ) -> bool {
         let Some(bytes) = bytes else {
             tracing::warn!("cw app verify: block not delivered (nullify)");
             return false;
@@ -226,6 +267,38 @@ impl GlobalProposer for AppSeamProposer {
         };
         if app_frame_digest(&frame) != Some(digest) {
             tracing::warn!(frame = header.frame_number, "cw app verify: digest mismatch");
+            return false;
+        }
+        let parent_frame_number = match self
+            .block_meta
+            .lock()
+            .unwrap()
+            .get(&parent_digest)
+            .copied()
+        {
+            Some(frame_number) => frame_number,
+            None => {
+                tracing::warn!(
+                    view,
+                    parent = %hex::encode(digest_to_identity(&parent_digest)),
+                    "cw app verify: consensus parent metadata unavailable — nullify",
+                );
+                return false;
+            }
+        };
+        if !app_header_extends_simplex_parent(
+            header,
+            &self.filter,
+            view,
+            parent_frame_number,
+            &parent_digest,
+        ) {
+            tracing::warn!(
+                view,
+                frame = header.frame_number,
+                parent_frame = parent_frame_number,
+                "cw app verify: shard/rank/height/parent does not match Simplex context — nullify",
+            );
             return false;
         }
         // Proposal-mode validation: VDF + structure, no committee QC required yet.
@@ -534,5 +607,32 @@ mod tests {
             &app_a,
         )
         .is_none());
+    }
+
+    #[test]
+    fn app_header_must_extend_simplex_parent() {
+        let filter = vec![0xAA; 32];
+        let parent = digest_from_identity([0x11; 32]);
+        let valid = quil_types::proto::global::FrameHeader {
+            address: filter.clone(),
+            frame_number: 8,
+            rank: 42,
+            parent_selector: digest_to_identity(&parent).to_vec(),
+            ..Default::default()
+        };
+        assert!(app_header_extends_simplex_parent(&valid, &filter, 42, 7, &parent));
+
+        let mut wrong = valid.clone();
+        wrong.frame_number = 7;
+        assert!(!app_header_extends_simplex_parent(&wrong, &filter, 42, 7, &parent));
+        let mut wrong = valid.clone();
+        wrong.parent_selector = vec![0x22; 32];
+        assert!(!app_header_extends_simplex_parent(&wrong, &filter, 42, 7, &parent));
+        let mut wrong = valid.clone();
+        wrong.rank = 43;
+        assert!(!app_header_extends_simplex_parent(&wrong, &filter, 42, 7, &parent));
+        let mut wrong = valid;
+        wrong.address = vec![0xBB; 32];
+        assert!(!app_header_extends_simplex_parent(&wrong, &filter, 42, 7, &parent));
     }
 }

--- a/crates/quil-engine/src/cw_global_seams.rs
+++ b/crates/quil-engine/src/cw_global_seams.rs
@@ -214,7 +214,13 @@ impl GlobalProposer for GlobalSeamProposer {
         Some((digest, bytes))
     }
 
-    fn verify(&self, view: u64, digest: Digest, bytes: Option<Vec<u8>>) -> bool {
+    fn verify(
+        &self,
+        view: u64,
+        _parent_digest: Digest,
+        digest: Digest,
+        bytes: Option<Vec<u8>>,
+    ) -> bool {
         let Some(bytes) = bytes else {
             // Block not yet delivered — nullify rather than vote blind.
             tracing::warn!(view, "cw verify: block not delivered (nullify)");

--- a/crates/quil-engine/tests/common/mod.rs
+++ b/crates/quil-engine/tests/common/mod.rs
@@ -972,6 +972,42 @@ impl AppShardHarness {
         }
         None
     }
+
+    /// Wait until one worker has observed `count` finalized shard frames, then
+    /// decode that worker's first `count` frames. Keeping frames from one worker
+    /// avoids counting one committee finalization once per replica when checking
+    /// chain continuity and frame-number uniqueness.
+    pub async fn wait_for_full_frames_from_one_worker(
+        &self,
+        count: usize,
+        timeout: std::time::Duration,
+    ) -> Option<Vec<gpb::AppShardFrame>> {
+        use prost::Message;
+
+        assert!(count > 0, "need at least one finalized frame");
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            for worker in &self.workers {
+                let captured = {
+                    let frames = worker.full_frames.lock();
+                    (frames.len() >= count)
+                        .then(|| frames.iter().take(count).cloned().collect::<Vec<_>>())
+                };
+                let Some(captured) = captured else {
+                    continue;
+                };
+                let decoded = captured
+                    .iter()
+                    .map(|bytes| gpb::AppShardFrame::decode(bytes.as_slice()).ok())
+                    .collect::<Option<Vec<_>>>();
+                if decoded.is_some() {
+                    return decoded;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        None
+    }
 }
 
 // =====================================================================

--- a/crates/quil-engine/tests/e2e_consensus.rs
+++ b/crates/quil-engine/tests/e2e_consensus.rs
@@ -19,6 +19,7 @@
 mod common;
 use common::*;
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -146,6 +147,55 @@ async fn app_consensus_cw_multi_prover_finalizes() {
         "app CW chain did not advance past genesis (frame_number = {})",
         header.frame_number
     );
+}
+
+/// Regression for #591: adjacent Simplex views may begin before the previous
+/// view's finalization callback reaches the app engine. Every worker must still
+/// observe one strictly connected, monotonically numbered finalized chain.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn app_consensus_cw_multi_prover_has_no_duplicate_frame_numbers() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_test_writer()
+        .try_init();
+
+    let harness = AppShardHarness::build_cw(3);
+    let frames = harness
+        .wait_for_full_frames_from_one_worker(4, std::time::Duration::from_secs(90))
+        .await
+        .expect("one 3-prover app CW replica should finalize four frames within 90s");
+    let headers = frames
+        .iter()
+        .map(|frame| frame.header.as_ref().expect("finalized frame has a header"))
+        .collect::<Vec<_>>();
+
+    let outputs = headers.iter().map(|header| &header.output).collect::<HashSet<_>>();
+    let numbers = headers
+        .iter()
+        .map(|header| header.frame_number)
+        .collect::<HashSet<_>>();
+    assert_eq!(outputs.len(), headers.len(), "finalized duplicate frame identities");
+    assert_eq!(numbers.len(), headers.len(), "finalized duplicate frame numbers");
+
+    for pair in headers.windows(2) {
+        let parent = pair[0];
+        let child = pair[1];
+        assert_eq!(
+            child.frame_number,
+            parent.frame_number + 1,
+            "finalized app chain contains a height gap",
+        );
+        let parent_identity = quil_crypto::poseidon::hash_bytes_to_32(&parent.output)
+            .expect("parent output hashes")
+            .to_vec();
+        assert_eq!(
+            child.parent_selector, parent_identity,
+            "finalized app frame does not extend its predecessor",
+        );
+    }
 }
 
 /// Active PoRep path end-to-end through the live consensus harness.


### PR DESCRIPTION
## Summary

- build app-shard proposals from the exact parent selected by Simplex instead of rereading a potentially lagging clock-store head
- verify shard, view, height, and parent linkage before voting
- serialize lossless finalization delivery and suppress stale, conflicting, gapped, or replayed downstream publication and coverage
- key proposal request and attestation data by frame number plus Simplex rank

## Validation

- Docker nextest regression matrix: 6 passed, including one-prover and three-prover consensus and the issue reproduction
- broader consensus and store suite: 105 passed
- Linux/amd64 production quil-node release build succeeded

Closes #591