### PR TITLE
Fix dropped finalized app-shard frames

### DIFF
--- a/crates/quil-cw-consensus/src/adapters.rs
+++ b/crates/quil-cw-consensus/src/adapters.rs
@@ -56,24 +56,82 @@ pub fn digest_to_identity(digest: &Digest) -> [u8; 32] {
     digest.0
 }
 
-/// Shared digest → frame-bytes store. `Automaton::propose` inserts the frame it
-/// built; `Relay` reads it to ship; `verify`/`Reporter` read it to validate /
-/// commit. Frames arriving from peers (over `FrameSink`'s transport) are also
-/// inserted here by the node's inbound path.
+/// Shared digest → frame-bytes store. `Automaton::propose` seals the frame it
+/// built; successful `verify` seals the exact peer bytes the application
+/// accepted. Frames arriving from peers remain replaceable candidates until
+/// application validation succeeds.
 #[derive(Clone, Default)]
 pub struct BlockStore {
-    inner: Arc<Mutex<HashMap<Digest, Vec<u8>>>>,
+    inner: Arc<Mutex<HashMap<Digest, StoredBlock>>>,
+}
+
+#[derive(Clone)]
+struct StoredBlock {
+    bytes: Vec<u8>,
+    verified: bool,
 }
 
 impl BlockStore {
     pub fn new() -> Self {
         Self::default()
     }
+    /// Insert an unverified block candidate. Candidates may be replaced until
+    /// one exact byte sequence passes application validation and is sealed.
+    /// Once sealed, peer ingress cannot substitute different bytes for the
+    /// consensus digest that was actually verified.
     pub fn put(&self, digest: Digest, bytes: Vec<u8>) {
-        self.inner.lock().insert(digest, bytes);
+        let mut inner = self.inner.lock();
+        match inner.get_mut(&digest) {
+            Some(stored) if stored.verified => {}
+            Some(stored) => stored.bytes = bytes,
+            None => {
+                inner.insert(
+                    digest,
+                    StoredBlock {
+                        bytes,
+                        verified: false,
+                    },
+                );
+            }
+        }
     }
     pub fn get(&self, digest: &Digest) -> Option<Vec<u8>> {
-        self.inner.lock().get(digest).cloned()
+        self.inner
+            .lock()
+            .get(digest)
+            .map(|stored| stored.bytes.clone())
+    }
+
+    /// Seal the exact bytes that passed application validation. This is atomic
+    /// with respect to peer ingress: even if another candidate arrived between
+    /// `get` and validation, the validated bytes become the immutable value.
+    pub fn seal(&self, digest: Digest, bytes: Vec<u8>) {
+        let mut inner = self.inner.lock();
+        if inner
+            .get(&digest)
+            .map(|stored| stored.verified)
+            .unwrap_or(false)
+        {
+            return;
+        }
+        inner.insert(
+            digest,
+            StoredBlock {
+                bytes,
+                verified: true,
+            },
+        );
+    }
+
+    /// Return the current bytes together with whether this node's application
+    /// validator accepted and sealed this exact value. A replica can learn a
+    /// finalization certificate before locally verifying its block, so the
+    /// reporter must preserve that distinction for the finalizer.
+    pub fn get_with_verification(&self, digest: &Digest) -> Option<(Vec<u8>, bool)> {
+        self.inner
+            .lock()
+            .get(digest)
+            .map(|stored| (stored.bytes.clone(), stored.verified))
     }
 }
 
@@ -118,7 +176,16 @@ pub trait FrameFinalizer: Send + Sync + 'static {
     /// Falcon quorum cert) — carried so the finalizer can attach it to a coverage
     /// bundle for off-chain / global-level verification (reward
     /// attribution). `None` if the reporter couldn't recover it.
-    fn on_finalized(&self, view: u64, digest: Digest, bytes: Option<Vec<u8>>, cert: Option<Vec<u8>>);
+    /// `locally_verified` is true only when the reported bytes are the immutable
+    /// value this node's application verifier accepted (or built locally).
+    fn on_finalized(
+        &self,
+        view: u64,
+        digest: Digest,
+        bytes: Option<Vec<u8>>,
+        cert: Option<Vec<u8>>,
+        locally_verified: bool,
+    );
     /// A proposer equivocated (double-propose/finalize). Drives a ProverKick.
     fn on_equivocation(&self, _view: u64) {}
 }
@@ -169,7 +236,9 @@ impl<E: Spawner + Clock + Send + 'static, Pr: GlobalProposer> Automaton
         let store = self.store.clone();
         self.context.child("propose").spawn(move |_| async move {
             if let Some((digest, bytes)) = proposer.propose(view, parent) {
-                store.put(digest, bytes);
+                // Locally-produced bytes came directly from the application
+                // proposer and are the value Simplex is about to certify.
+                store.seal(digest, bytes);
                 let _ = tx.send(digest);
             }
             // else: drop tx → receiver cancelled → simplex nullifies the view.
@@ -202,7 +271,13 @@ impl<E: Spawner + Clock + Send + 'static, Pr: GlobalProposer> Automaton
                 bytes = store.get(&payload);
                 waited += 1;
             }
+            let verified_bytes = bytes.clone();
             let ok = proposer.verify(view, payload, bytes);
+            if ok {
+                if let Some(bytes) = verified_bytes {
+                    store.seal(payload, bytes);
+                }
+            }
             let _ = tx.send(ok);
         });
         rx
@@ -296,12 +371,16 @@ impl<Fin: FrameFinalizer> Reporter for FalconReporter<Fin> {
             Activity::Finalization(f) => {
                 let digest = f.proposal.payload;
                 let view: u64 = f.proposal.round.view().get();
-                let bytes = self.store.get(&digest);
+                let (bytes, locally_verified) = self
+                    .store
+                    .get_with_verification(&digest)
+                    .map_or((None, false), |(bytes, verified)| (Some(bytes), verified));
                 // Serialize the finalization certificate (proposal + Falcon
                 // quorum cert) so the finalizer can carry it into a coverage
                 // bundle for global-level reward verification.
                 let cert = Some(crate::app_cert::encode_finalization(&f));
-                self.finalizer.on_finalized(view, digest, bytes, cert);
+                self.finalizer
+                    .on_finalized(view, digest, bytes, cert, locally_verified);
             }
             Activity::ConflictingNotarize(_)
             | Activity::ConflictingFinalize(_)
@@ -313,5 +392,58 @@ impl<Fin: FrameFinalizer> Reporter for FalconReporter<Fin> {
             _ => {}
         }
         Feedback::Ok
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(byte: u8) -> Digest {
+        digest_from_identity([byte; 32])
+    }
+
+    #[test]
+    fn unverified_candidates_are_distinguished_from_verified_blocks() {
+        let store = BlockStore::new();
+        let block = digest(1);
+
+        store.put(block, b"candidate".to_vec());
+
+        assert_eq!(store.get(&block), Some(b"candidate".to_vec()));
+        assert_eq!(
+            store.get_with_verification(&block),
+            Some((b"candidate".to_vec(), false))
+        );
+    }
+
+    #[test]
+    fn verified_bytes_cannot_be_substituted() {
+        let store = BlockStore::new();
+        let block = digest(2);
+        let verified = b"committee-validated bytes".to_vec();
+
+        store.put(block, verified.clone());
+        store.seal(block, verified.clone());
+        store.put(block, b"same digest, substituted body".to_vec());
+
+        assert_eq!(store.get(&block), Some(verified.clone()));
+        assert_eq!(store.get_with_verification(&block), Some((verified, true)));
+    }
+
+    #[test]
+    fn sealing_uses_the_bytes_that_were_validated() {
+        let store = BlockStore::new();
+        let block = digest(3);
+        let validated = b"validated candidate".to_vec();
+
+        store.put(block, validated.clone());
+        // Model peer ingress racing between Automaton's read and the end of
+        // application validation. `seal` must restore and freeze the clone that
+        // was actually checked, not whichever candidate is currently stored.
+        store.put(block, b"racing replacement".to_vec());
+        store.seal(block, validated.clone());
+
+        assert_eq!(store.get_with_verification(&block), Some((validated, true)));
     }
 }

--- a/crates/quil-cw-consensus/tests/falcon_adapters.rs
+++ b/crates/quil-cw-consensus/tests/falcon_adapters.rs
@@ -68,7 +68,14 @@ struct SignalFinalizer {
 }
 impl FrameFinalizer for SignalFinalizer {
     fn on_notarized(&self, _v: u64, _d: Sha256Digest, _b: Option<Vec<u8>>) {}
-    fn on_finalized(&self, view: u64, _d: Sha256Digest, _b: Option<Vec<u8>>, _c: Option<Vec<u8>>) {
+    fn on_finalized(
+        &self,
+        view: u64,
+        _d: Sha256Digest,
+        _b: Option<Vec<u8>>,
+        _c: Option<Vec<u8>>,
+        _locally_verified: bool,
+    ) {
         let _ = self.tx.send_lossy(view);
     }
 }

--- a/crates/quil-cw-consensus/tests/falcon_tokio.rs
+++ b/crates/quil-cw-consensus/tests/falcon_tokio.rs
@@ -50,7 +50,14 @@ struct SignalFinalizer {
 }
 impl FrameFinalizer for SignalFinalizer {
     fn on_notarized(&self, _v: u64, _d: Sha256Digest, _b: Option<Vec<u8>>) {}
-    fn on_finalized(&self, view: u64, _d: Sha256Digest, _b: Option<Vec<u8>>, _c: Option<Vec<u8>>) {
+    fn on_finalized(
+        &self,
+        view: u64,
+        _d: Sha256Digest,
+        _b: Option<Vec<u8>>,
+        _c: Option<Vec<u8>>,
+        _locally_verified: bool,
+    ) {
         let _ = self.tx.send(view);
     }
 }

--- a/crates/quil-engine/src/app_engine.rs
+++ b/crates/quil-engine/src/app_engine.rs
@@ -80,7 +80,11 @@ pub enum AppEngineMessage {
     /// aggregate in the header). `cert` is the serialized simplex finalization
     /// certificate, attached to the reward-coverage bundle for global-level
     /// verification.
-    CwFinalizedFrame { frame: Vec<u8>, cert: Vec<u8> },
+    CwFinalizedFrame {
+        frame: Vec<u8>,
+        cert: Vec<u8>,
+        locally_verified: bool,
+    },
     /// (P3) An inbound commonware-simplex message from a committee peer, demuxed
     /// from `shard_cw_bitmask` gossip. `channel` = CW channel id; `from` = the
     /// sender's committee Falcon public-key bytes (resolved by the master from
@@ -1819,8 +1823,13 @@ impl AppConsensusEngine {
                         Some(AppEngineMessage::ShardSyncCompleted { synced_to_frame }) => {
                             self.reconcile_with_sync(synced_to_frame).await;
                         }
-                        Some(AppEngineMessage::CwFinalizedFrame { frame, cert }) => {
-                            self.handle_cw_finalized_frame(&frame, &cert).await;
+                        Some(AppEngineMessage::CwFinalizedFrame {
+                            frame,
+                            cert,
+                            locally_verified,
+                        }) => {
+                            self.handle_cw_finalized_frame(&frame, &cert, locally_verified)
+                                .await;
                         }
                         Some(AppEngineMessage::CwIn { channel, from, data }) => {
                             if let Some(h) = self.cw_handle.as_ref() {
@@ -2122,10 +2131,14 @@ impl AppConsensusEngine {
         // `handle_cw_finalized_frame` materializes it on `&mut self`.
         let on_finalized: crate::cw_app_seams::AppFinalizedSink = {
             let msg_tx = self.self_msg_tx.clone();
-            Arc::new(move |frame, cert| {
+            Arc::new(move |frame, cert, locally_verified| {
                 let mut buf = Vec::new();
                 if prost::Message::encode(&frame, &mut buf).is_ok() {
-                    let _ = msg_tx.try_send(AppEngineMessage::CwFinalizedFrame { frame: buf, cert });
+                    let _ = msg_tx.try_send(AppEngineMessage::CwFinalizedFrame {
+                        frame: buf,
+                        cert,
+                        locally_verified,
+                    });
                 }
             })
         };
@@ -2317,7 +2330,12 @@ impl AppConsensusEngine {
     /// self-materialize half of [`distribute_and_materialize_own_frame`]: apply
     /// the requests, advance + persist the durable cursor, and publish the full
     /// frame for followers/archives on `shard_frame_bitmask`.
-    async fn handle_cw_finalized_frame(&mut self, data: &[u8], cert: &[u8]) {
+    async fn handle_cw_finalized_frame(
+        &mut self,
+        data: &[u8],
+        cert: &[u8],
+        locally_verified: bool,
+    ) {
         let mut frame: quil_types::proto::global::AppShardFrame = match prost::Message::decode(data) {
             Ok(f) => f,
             Err(e) => {
@@ -2325,78 +2343,64 @@ impl AppConsensusEngine {
                 return;
             }
         };
-        // SECURITY — post-verification substitution defense (audit Finding #1).
-        // These finalized `data` bytes are a FRESH read of the mutable
-        // `BlockStore` (the reporter re-reads by digest at finalize), so they
-        // can differ from the bytes the committee actually verified at proposal
-        // time: the store is last-writer-wins and the block channel (3) has no
-        // committee admission. A substitution keeps the certified
-        // `Poseidon(output)` digest (so the finalization cert still verifies)
-        // while changing every other header field and the body. Re-run PROPOSAL
-        // validation here before anything touches the clock store or
-        // materializer: it RECOMPUTES the deterministic output from the declared
-        // fields (parent_selector, requests_root, state_roots, ρ_N, frame_number,
-        // rank, prover) and rejects any frame whose fields don't reproduce
-        // `header.output`. Honest frames (same bytes as verified) pass; a
-        // substituted/internally-inconsistent header is dropped. (Validate the
-        // PRISTINE frame, before the cert is attached below.)
-        if let Some(v) = self.app_frame_validator.as_ref() {
-            match validate_app_frame_panic_safe(v, &frame, /* proposal */ true) {
-                Ok(true) => {}
-                other => {
+        // A locally verified value is the exact byte sequence the BlockStore
+        // sealed when this node's application validator accepted it. Do not
+        // repeat proposal validation for that value: storage attestations and
+        // global-frame anchors come from mutable local state, so the same frame
+        // can fail later even though this node already voted for it.
+        //
+        // A replica may instead learn a finalization certificate without first
+        // verifying the block locally (for example during replay/catch-up). Such
+        // unsealed bytes still take the defensive validation path before being
+        // persisted or materialized.
+        if !locally_verified {
+            if let Some(v) = self.app_frame_validator.as_ref() {
+                match validate_app_frame_panic_safe(v, &frame, /* proposal */ true) {
+                    Ok(true) => {}
+                    other => {
+                        warn!(
+                            core_id = self.core_id,
+                            result = ?other,
+                            "cw finalized frame: unverified bytes failed validation — dropping",
+                        );
+                        return;
+                    }
+                }
+            }
+            if let (Some(exec), Some(header)) =
+                (self.execution_engine.as_ref(), frame.header.as_ref())
+            {
+                let canonical: Vec<Vec<u8>> = frame
+                    .requests
+                    .iter()
+                    .filter_map(|b| {
+                        crate::consensus_wire::proto_message_bundle_to_canonical_bytes(b).ok()
+                    })
+                    .collect();
+                let use_forest = self
+                    .hypergraph
+                    .as_ref()
+                    .map(|h| h.has_forest())
+                    .unwrap_or(false);
+                let ok = canonical.len() == frame.requests.len()
+                    && compute_requests_root(
+                        &canonical,
+                        &self.app_address,
+                        header.frame_number,
+                        Some(exec.as_ref()),
+                        self.inclusion_prover.as_deref(),
+                        use_forest,
+                    )
+                    .map(|r| r == header.requests_root)
+                    .unwrap_or(false);
+                if !ok {
                     warn!(
                         core_id = self.core_id,
-                        result = ?other,
-                        "cw finalized frame: failed re-validation (post-verification \
-                         substitution or inconsistent header) — dropping",
+                        frame = header.frame_number,
+                        "cw finalized frame: unverified body does not match requests_root — dropping",
                     );
                     return;
                 }
-            }
-        }
-        // SECURITY — body-root cross-check (audit Finding #2, and the body-swap
-        // case of #1). The re-validation above binds the DECLARED `requests_root`
-        // through output recomputation, but not the carried body; a finalize-time
-        // BlockStore overwrite can keep the whole header (hence the certified
-        // digest) while swapping `frame.requests`. Recompute the body root from
-        // the carried requests and DROP on mismatch, so no CW replica ever
-        // materializes a body its certified root does not cover. (Dropping a
-        // substituted body stalls at worst — recoverable via catch-up — whereas
-        // materializing it would be an unrecoverable state divergence.)
-        if let (Some(exec), Some(header)) =
-            (self.execution_engine.as_ref(), frame.header.as_ref())
-        {
-            let canonical: Vec<Vec<u8>> = frame
-                .requests
-                .iter()
-                .filter_map(|b| {
-                    crate::consensus_wire::proto_message_bundle_to_canonical_bytes(b).ok()
-                })
-                .collect();
-            let use_forest = self
-                .hypergraph
-                .as_ref()
-                .map(|h| h.has_forest())
-                .unwrap_or(false);
-            let ok = canonical.len() == frame.requests.len()
-                && compute_requests_root(
-                    &canonical,
-                    &self.app_address,
-                    header.frame_number,
-                    Some(exec.as_ref()),
-                    self.inclusion_prover.as_deref(),
-                    use_forest,
-                )
-                .map(|r| r == header.requests_root)
-                .unwrap_or(false);
-            if !ok {
-                warn!(
-                    core_id = self.core_id,
-                    frame = header.frame_number,
-                    "cw finalized frame: requests_root mismatch (carried body does not \
-                     match the certified root) — dropping (post-verification body swap)",
-                );
-                return;
             }
         }
         // Attach the simplex FINALIZATION cert to the frame header so every
@@ -3881,6 +3885,152 @@ fn validate_app_frame_panic_safe(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quil_types::crypto::Signer as _;
+
+    /// Regression for #589. Proposal validation may depend on mutable local
+    /// state (here, availability of the anchored global frame). Once Simplex
+    /// has accepted and finalized the proposal, a replica must apply the sealed
+    /// bytes it already validated instead of rerunning that stateful gate.
+    #[tokio::test]
+    async fn cw_finalization_does_not_repeat_stateful_proposal_validation() {
+        let filter = vec![0x59; 32];
+        let shard_store = Arc::new(quil_store::testing::InMemoryClockStore::new());
+        let voting_anchor_store = Arc::new(quil_store::testing::InMemoryClockStore::new());
+        let lagging_anchor_store = Arc::new(quil_store::testing::InMemoryClockStore::new());
+        let global_output = vec![0xA5; 516];
+        voting_anchor_store.seed_frame(quil_types::proto::global::GlobalFrame {
+            header: Some(quil_types::proto::global::GlobalFrameHeader {
+                frame_number: 5,
+                output: global_output.clone(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_millis() as i64;
+        let parent_selector = vec![0u8; 32];
+        let requests_root = Vec::new();
+        let state_roots = vec![vec![0u8; 32]; 4];
+        let prover = vec![0x33; 32];
+        let rho_n = quil_crypto::porep::derive_storage_beacon(5, &global_output);
+        let output = quil_crypto::porep::deterministic_app_frame_output(
+            &parent_selector,
+            &requests_root,
+            &state_roots,
+            &rho_n,
+            1,
+            1,
+            &prover,
+            1,
+            1,
+            timestamp,
+            &[],
+        );
+        let frame = quil_types::proto::global::AppShardFrame {
+            header: Some(quil_types::proto::global::FrameHeader {
+                address: filter.clone(),
+                frame_number: 1,
+                rank: 1,
+                timestamp,
+                difficulty: 1,
+                output,
+                parent_selector,
+                requests_root,
+                state_roots,
+                prover,
+                fee_multiplier_vote: 1,
+                global_frame_number: 5,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let registry = Arc::new(crate::test_support::TestProverRegistry::default());
+        let frame_prover = Arc::new(quil_crypto::WesolowskiFrameProver::new(2048));
+        let voting_validator = BlsAppFrameValidator::new(
+            registry.clone(),
+            Arc::new(quil_crypto::FalconKeyConstructor),
+            frame_prover.clone(),
+        )
+        .with_clock_store(voting_anchor_store);
+        assert!(
+            voting_validator
+                .validate_proposal(&frame)
+                .expect("proposal is valid while its global anchor is available"),
+            "the regression frame must pass the committee's vote-time gate"
+        );
+
+        let signer = quil_crypto::FalconSigner::generate();
+        let deps = AppEngineDeps {
+            clock_store: shard_store.clone(),
+            global_anchor_store: None,
+            prover_registry: registry.clone(),
+            frame_prover: frame_prover.clone(),
+            message_collector: Arc::new(MessageCollector::new()),
+            fee_manager: Arc::new(crate::InMemoryDynamicFeeManager::new(32)),
+            local_prover_address: vec![0x44; 32],
+            local_bls_pubkey: signer.public_key().to_vec(),
+            bls_signer: Box::new(signer),
+            reward_greedy: false,
+            min_active_provers_for_propose: 1,
+            coverage_publish: None,
+            hypergraph: None,
+            storage_source_hypergraph: None,
+            execution_engine: None,
+            inclusion_prover: None,
+            kv_db: None,
+            app_consensus_cw: true,
+            db_config: quil_config::DbConfig::default(),
+        };
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (mut engine, _handle) = AppConsensusEngine::new(1, filter.clone(), deps, event_tx);
+        // Model finalize-time local-state drift: the same validator can no
+        // longer resolve rho_N because this replica's global store is behind.
+        engine.app_frame_validator = Some(Arc::new(
+            BlsAppFrameValidator::new(
+                registry,
+                Arc::new(quil_crypto::FalconKeyConstructor),
+                frame_prover,
+            )
+            .with_clock_store(lagging_anchor_store),
+        ));
+
+        let encoded = prost::Message::encode_to_vec(&frame);
+
+        // A certificate-only replica must not blindly trust block bytes it did
+        // not validate. Its lagging anchor makes this defensive path reject.
+        engine
+            .handle_cw_finalized_frame(&encoded, &[], false)
+            .await;
+        assert!(shard_store.get_latest_shard_clock_frame(&filter).is_err());
+        assert!(event_rx.try_recv().is_err());
+
+        // The exact bytes sealed when this replica voted remain finalizable
+        // even though the mutable anchor state has since fallen behind.
+        engine
+            .handle_cw_finalized_frame(&encoded, &[], true)
+            .await;
+
+        assert_eq!(
+            shard_store
+                .get_latest_shard_clock_frame(&filter)
+                .expect("committee-finalized frame must be persisted")
+                .header
+                .expect("persisted frame has a header")
+                .frame_number,
+            1
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(AppEngineEvent::FullFrameProduced {
+                frame_number: 1,
+                ..
+            })
+        ));
+    }
 
     /// Go parity (`app_consensus_engine.go:718`): core 0 → `db.path`; worker
     /// core N → `worker_paths[N-1]` else `worker_path_prefix` (`%d`→N); empty

--- a/crates/quil-engine/src/cw_app_seams.rs
+++ b/crates/quil-engine/src/cw_app_seams.rs
@@ -53,8 +53,9 @@ pub type AppFrameSink = Arc<dyn Fn(AppShardFrame) + Send + Sync>;
 
 /// Like [`AppFrameSink`] but also carries the serialized simplex finalization
 /// certificate (proposal + Falcon quorum cert), so the engine can attach it to
-/// the reward-coverage bundle for global-level verification.
-pub type AppFinalizedSink = Arc<dyn Fn(AppShardFrame, Vec<u8>) + Send + Sync>;
+/// the reward-coverage bundle for global-level verification. The boolean marks
+/// whether this exact frame was locally validated and sealed before finalization.
+pub type AppFinalizedSink = Arc<dyn Fn(AppShardFrame, Vec<u8>, bool) + Send + Sync>;
 
 /// Build the full `AppShardFrame` from a produced consensus state + the leader's
 /// recorded request bundles. Mirrors the finalized-frame rebuild at
@@ -343,10 +344,17 @@ impl FrameFinalizer for AppSeamFinalizer {
         (self.on_notarized)(frame);
     }
 
-    fn on_finalized(&self, _view: u64, _digest: Digest, bytes: Option<Vec<u8>>, cert: Option<Vec<u8>>) {
+    fn on_finalized(
+        &self,
+        _view: u64,
+        _digest: Digest,
+        bytes: Option<Vec<u8>>,
+        cert: Option<Vec<u8>>,
+        locally_verified: bool,
+    ) {
         let Some(bytes) = bytes else { return };
         let Some(frame) = decode_app_frame(&bytes) else { return };
-        (self.on_finalized)(frame, cert.unwrap_or_default());
+        (self.on_finalized)(frame, cert.unwrap_or_default(), locally_verified);
     }
 }
 

--- a/crates/quil-engine/src/cw_global_seams.rs
+++ b/crates/quil-engine/src/cw_global_seams.rs
@@ -380,14 +380,19 @@ impl FrameFinalizer for GlobalSeamFinalizer {
         }
     }
 
-    fn on_finalized(&self, _view: u64, _digest: Digest, bytes: Option<Vec<u8>>, cert: Option<Vec<u8>>) {
+    fn on_finalized(
+        &self,
+        _view: u64,
+        _digest: Digest,
+        bytes: Option<Vec<u8>>,
+        cert: Option<Vec<u8>>,
+        _locally_verified: bool,
+    ) {
         let Some(bytes) = bytes else { return };
         let Ok(mut frame) = decode_global_frame(&bytes) else { return };
         // Re-bind the body to the header at FINALIZE, not just at verify. The
-        // block bytes are re-read from the shared (overwrite-able) BlockStore by
-        // digest, so a body swapped in AFTER this node voted would otherwise be
-        // materialized. Recompute the requests root and drop on mismatch — the
-        // "post-verification body swap" guard the app-shard seam also has.
+        // Certificate-only replicas may not have locally verified these bytes,
+        // so retain this context-free body check at the persistence boundary.
         if let Some(h) = frame.header.as_ref() {
             if !crate::frame_validator::global_frame_body_matches_requests_root(h, &frame.requests) {
                 tracing::warn!(


### PR DESCRIPTION
Closes #589

## Summary

- seal the exact app-frame bytes accepted by the local Simplex application validator so peer ingress cannot substitute them before finalization
- propagate whether finalized bytes were locally verified
- skip mutable proposal revalidation only for those sealed bytes, preventing prover-registry or global-anchor drift from dropping a frame this replica already accepted
- retain defensive validation for certificate-only replicas that did not locally verify the block

## Validation

- `quil-cw-consensus`: 17 tests passed
- `quil-engine --lib`: 476 tests passed
- deterministic #589 regression covers unavailable finalize-time global anchor for both locally verified and certificate-only paths
- Linux AMD64 release node built successfully through `docker/Dockerfile.source` (`target=node`)

Please review the trust-boundary split between sealed locally verified bytes and the defensive certificate-only path in particular.