### PR TITLE
fix: restore app engine build after finalized-sink merge

### DIFF
--- a/crates/quil-engine/src/app_engine.rs
+++ b/crates/quil-engine/src/app_engine.rs
@@ -72,9 +72,13 @@ pub enum AppEngineMessage {
     /// could be re-applied on top of the already-synced tree.
     ShardSyncCompleted { synced_to_frame: u64 },
     /// (P3 / commonware-simplex) A frame this shard's simplex engine FINALIZED
-    /// (prost-encoded `AppShardFrame`). Routed from `AppSeamFinalizer::on_finalized`
-    /// (which runs on the simplex engine thread) into the engine run loop so it
-    /// materializes on the worker's `&mut self`. Trusted — simplex already
+    /// (prost-encoded `AppShardFrame`), injected into the engine run loop so it
+    /// materializes on the worker's `&mut self`. The simplex thread's own
+    /// `AppSeamFinalizer::on_finalized` does NOT travel this bounded queue — it
+    /// uses the dedicated unbounded `cw_finalized_tx`, so a full inbound queue
+    /// can never drop a certified frame; this variant is the out-of-band
+    /// injection path for callers holding an `AppEngineHandle`. Trusted — simplex
+    /// already
     /// certified it via quorum — so it SKIPS the BLS-quorum-signature check that
     /// `Frame` requires (a CW frame carries a Falcon certificate, not a BLS
     /// aggregate in the header). `cert` is the serialized simplex finalization
@@ -1353,8 +1357,12 @@ pub struct AppConsensusEngine {
     /// Lossless, ordered handoff from the dedicated Simplex runtime thread to
     /// this engine's finalization handler. Finalizations are safety-critical and
     /// must not compete for capacity with the best-effort inbound message queue.
-    cw_finalized_tx: mpsc::UnboundedSender<(Vec<u8>, Vec<u8>)>,
-    cw_finalized_rx: Option<mpsc::UnboundedReceiver<(Vec<u8>, Vec<u8>)>>,
+    /// Payload: `(encoded AppShardFrame, finalization cert, locally_verified)`.
+    /// `locally_verified` marks the bytes this replica's own application
+    /// validator sealed at proposal time, so the finalize handler can skip
+    /// re-validating them against since-drifted local state.
+    cw_finalized_tx: mpsc::UnboundedSender<(Vec<u8>, Vec<u8>, bool)>,
+    cw_finalized_rx: Option<mpsc::UnboundedReceiver<(Vec<u8>, Vec<u8>, bool)>>,
 
     /// Atomic publish slot for engine sizes. Updated each event-loop
     /// iteration so external memory snapshots can read internal
@@ -1813,8 +1821,8 @@ impl AppConsensusEngine {
                 biased;
 
                 finalized = cw_finalized_rx.recv() => {
-                    if let Some((frame, cert)) = finalized {
-                        self.handle_cw_finalized_frame(&frame, &cert).await;
+                    if let Some((frame, cert, locally_verified)) = finalized {
+                        self.handle_cw_finalized_frame(&frame, &cert, locally_verified).await;
                     }
                 }
 
@@ -2167,14 +2175,11 @@ impl AppConsensusEngine {
         // drop the certified parent while Simplex advances to its child, leaving
         // the worker permanently unable to materialize the selected parent.
         let on_finalized: crate::cw_app_seams::AppFinalizedSink = {
+            let finalized_tx = self.cw_finalized_tx.clone();
             Arc::new(move |frame, cert, locally_verified| {
                 let mut buf = Vec::new();
                 if prost::Message::encode(&frame, &mut buf).is_ok() {
-                    let _ = msg_tx.try_send(AppEngineMessage::CwFinalizedFrame {
-                        frame: buf,
-                        cert,
-                        locally_verified,
-                    });
+                    let _ = finalized_tx.send((buf, cert, locally_verified));
                 }
             })
         };
@@ -4386,7 +4391,7 @@ mod tests {
         let mut gap = test_shard_frame(&filter, 9, 0x09);
         gap.header.as_mut().expect("gap frame header").parent_selector = parent_identity.clone();
         engine
-            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&gap), &[])
+            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&gap), &[], true)
             .await;
         assert!(event_rx.try_recv().is_err(), "gap finalization must not publish");
         assert_eq!(coverage_count.load(std::sync::atomic::Ordering::SeqCst), 0);
@@ -4405,7 +4410,7 @@ mod tests {
         wrong_parent.header.as_mut().expect("wrong-parent frame header").parent_selector =
             vec![0xFF; 32];
         engine
-            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&wrong_parent), &[])
+            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&wrong_parent), &[], true)
             .await;
         assert!(
             event_rx.try_recv().is_err(),
@@ -4425,7 +4430,7 @@ mod tests {
         let mut frame = test_shard_frame(&filter, 8, 0x08);
         frame.header.as_mut().expect("frame header").parent_selector = parent_identity;
         let encoded = prost::Message::encode_to_vec(&frame);
-        engine.handle_cw_finalized_frame(&encoded, &[]).await;
+        engine.handle_cw_finalized_frame(&encoded, &[], true).await;
 
         let first_events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
         assert_eq!(
@@ -4455,7 +4460,7 @@ mod tests {
             vec![0x08; 516]
         );
 
-        engine.handle_cw_finalized_frame(&encoded, &[]).await;
+        engine.handle_cw_finalized_frame(&encoded, &[], true).await;
         assert!(
             event_rx.try_recv().is_err(),
             "identical finalization replay must not republish"
@@ -4469,7 +4474,7 @@ mod tests {
         let mut conflicting = frame;
         conflicting.header.as_mut().expect("conflicting frame header").output = vec![0xF8; 516];
         engine
-            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&conflicting), &[])
+            .handle_cw_finalized_frame(&prost::Message::encode_to_vec(&conflicting), &[], true)
             .await;
         assert!(
             event_rx.try_recv().is_err(),


### PR DESCRIPTION
## Problem

`task build_node_amd64_linux` fails on `v2.1.0.25`: `quil-engine` does not compile, so the `build-node` stage exits 101.

```
error[E0425]: cannot find value `msg_tx` in this scope
    --> crates/quil-engine/src/app_engine.rs:2173:29
error[E0061]: this method takes 3 arguments but 2 arguments were supplied
    --> crates/quil-engine/src/app_engine.rs:1817:30
```

## Cause

A semantic merge conflict between two PRs that changed the same finalization path from different bases:

- **#593** moved simplex finalizations off the bounded inbound queue onto the  dedicated unbounded `cw_finalized_tx`/`cw_finalized_rx` channel carrying `(frame, cert)`, plus a run-loop `select!` arm — so a saturated message queue can no longer drop a certified parent frame.
- **#594** added `locally_verified: bool` to the finalized sink and to `handle_cw_finalized_frame`, but was written against the pre-#593 base and still routed through `AppEngineMessage::CwFinalizedFrame` on the bounded `msg_tx`.

Both merged cleanly as text. The result keeps #593's channel and run-loop arm while the `on_finalized` closure carries #594's body, which references a `msg_tx` binding that no longer exists (E0425); the channel arm still calls the handler with two arguments (E0061).

## Fix

Keeps both intents rather than reverting either:

- `cw_finalized_tx`/`cw_finalized_rx` now carry `(frame, cert, locally_verified)`.
- `on_finalized` restores the `finalized_tx` binding and sends the flag over the unbounded channel, so the lossless handoff #593 introduced is preserved.
- The run-loop arm destructures the 3-tuple and forwards `locally_verified` to `handle_cw_finalized_frame`, so #594's skip-revalidation-of-locally-sealed-bytes behaviour is preserved.
- `AppEngineMessage::CwFinalizedFrame` remains as the out-of-band injection path for `AppEngineHandle` holders; its doc comment no longer claims the simplex thread routes through it.
- The four unit tests added by #593 pass `locally_verified = true`, matching their setup of locally sealed bytes. Those engines have no validator or execution engine, so the defensive branch is a no-op either way and the tests still exercise the continuity guards they were written for.

One file changed, `crates/quil-engine/src/app_engine.rs`. No behaviour change beyond making the merged intent compile.

## Verification

- `task build_node_amd64_linux` — passes.
- `task build_qclient_amd64_linux` — passes.
- `task test_rust_amd64_linux` — `Summary [481.063s] 2924 tests run: 2924 passed
  (19 slow), 21 skipped`.
- `cargo check --locked -p quil-engine -p quil-node -p quil-cw-consensus
  --all-targets` inside the build image — clean (warnings only), confirming the test targets compile as well.
