### PR TITLE
chore: drop unused imports and bindings in the crypto crates

### DIFF
--- a/crates/bls48581-wasm/src/lib.rs
+++ b/crates/bls48581-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 use bls48581::{
     init, commit_raw, prove_raw, verify_raw, bls_keygen, bls_sign, bls_verify, bls_aggregate,
-    prove_multiple, verify_multiple, Multiproof, BlsKeygenOutput, BlsAggregateOutput,
+    prove_multiple, verify_multiple,
     bls_scalar_random, bls_scalar_mul, bls_scalar_add, bls_scalar_sub, bls_scalar_neg,
     bls_scalar_inv, bls_scalar_from_u64, bls_scalar_to_g1, bls_g1_add,
     bls_scalar_to_g8, bls_g8_add,

--- a/crates/bls48581/src/bls48581/ecp.rs
+++ b/crates/bls48581/src/bls48581/ecp.rs
@@ -1359,7 +1359,7 @@ impl ECP {
 
         let num_buckets = 1usize << (w - 1);         // |digit| ranges 1..2^(w-1)
         let half = 1usize << (w - 1);              // 2^(w-1)
-        let mask = (1isize << w) - 1;              // 2^w - 1
+        let _mask = (1isize << w) - 1;              // 2^w - 1
         let nb = (max_bits + w - 1) / w + 1;       // +1 for potential carry overflow
 
         // 3. Signed-digit decomposition for each scalar

--- a/crates/bls48581/src/lib.rs
+++ b/crates/bls48581/src/lib.rs
@@ -32,15 +32,12 @@ pub mod hash512;
 pub mod sha3;
 
 use std::error::Error;
-use std::fs;
 use bls48581::big;
 use bls48581::ecp;
 use bls48581::ecp::ECP;
 use bls48581::ecp8;
-use bls48581::mpin256::SHA512;
 use bls48581::rom;
 use bls48581::pair8;
-use ::rand::rngs;
 use ::rand::RngCore;
 
 uniffi::include_scaffolding!("lib");
@@ -54,7 +51,7 @@ fn recurse_fft(
     fft_width: u64,
     inverse: bool,
 ) {
-  let M = &big::BIG::new_ints(&rom::CURVE_ORDER);
+  let _M = &big::BIG::new_ints(&rom::CURVE_ORDER);
   let roots = if inverse {
     &bls::singleton().ReverseRootsOfUnityBLS48581[&fft_width]
   } else {
@@ -1470,17 +1467,17 @@ pub fn prove_multiple(
 
     // 1. Fiat–Shamir challenge  ρ
     let mut fs_input = Vec::<u8>::new();
-    for (i, c) in commits.iter().enumerate() {
+    for (_i, c) in commits.iter().enumerate() {
         let mut tmp = [0u8; 74];
         c.tobytes(&mut tmp, true);
         fs_input.extend_from_slice(&tmp);
     }
-    for (i, s) in y.iter().enumerate() {
+    for (_i, s) in y.iter().enumerate() {
         let mut tmp = [0u8; 73];
         s.tobytes(&mut tmp);
         fs_input.extend_from_slice(&tmp);
     }
-    for (i, &idx) in indices.iter().enumerate() { 
+    for (_i, &idx) in indices.iter().enumerate() { 
         fs_input.extend_from_slice(&idx.to_le_bytes()); 
     }
     let rho = hash_to_scalar(&fs_input);
@@ -1536,12 +1533,12 @@ pub fn prove_multiple(
 
     // 5. Compute h(x) =  Σ ρᶦ · (fᵢ(X))/(t − zᵢ)
     let mut acc_pow = big::BIG::new_int(1);
-    for ((index, blob), (&idx, y_i)) in polys.iter().enumerate().zip(indices.iter().zip(y.iter())) {
+    for ((index, _blob), (&idx, _y_i)) in polys.iter().enumerate().zip(indices.iter().zip(y.iter())) {
         let mut coeffs = f_evals[index].clone();
         let z_i = bls::singleton().RootsOfUnityBLS48581[&poly_size][idx as usize].clone();
         let mut den = big::BIG::modadd(&t, &big::BIG::modneg(&z_i, &modulus), &modulus);
         den.invmodp(&modulus);
-        for (i, dst) in coeffs.iter_mut().enumerate() {
+        for (_i, dst) in coeffs.iter_mut().enumerate() {
           *dst = big::BIG::modmul(dst, &acc_pow, &modulus);
           *dst = big::BIG::modmul(dst, &den, &modulus);
         }
@@ -1557,7 +1554,7 @@ pub fn prove_multiple(
       &bls::singleton().CeremonyBLS48581G1[..(hx.len())],
       &hx,
     ).unwrap();
-    let mut g2x: Vec<big::BIG> = hx.iter().zip(qx).map(|(h, q)| big::BIG::modadd(h, &big::BIG::modneg(&q, &modulus), &modulus)).collect();
+    let g2x: Vec<big::BIG> = hx.iter().zip(qx).map(|(h, q)| big::BIG::modadd(h, &big::BIG::modneg(&q, &modulus), &modulus)).collect();
 
     let mut c_h_bytes = [0u8; 74];
     c_h.tobytes(&mut c_h_bytes, true);
@@ -1614,21 +1611,21 @@ pub fn verify_multiple(
 
     let mut c_points: Vec<ecp::ECP> = Vec::with_capacity(m); // Cᵢ
     let mut y_scalars: Vec<big::BIG> = Vec::with_capacity(m); // yᵢ
-    for (i, (c_bytes, y_b)) in commits.iter().zip(y_bytes).enumerate() {
+    for (_i, (c_bytes, y_b)) in commits.iter().zip(y_bytes).enumerate() {
         c_points.push(ecp::ECP::frombytes(&c_bytes));
         y_scalars.push(big::BIG::frombytes(&y_b));
     }
 
     // 1. Re‑derive ρ
     let mut fs_input = Vec::<u8>::new();
-    for (i, b) in commits.iter().enumerate() {
+    for (_i, b) in commits.iter().enumerate() {
       fs_input.extend_from_slice(b);
     }
-    for (i, b) in y_bytes.iter().enumerate() {
+    for (_i, b) in y_bytes.iter().enumerate() {
       fs_input.extend_from_slice(&[0u8;9]);
       fs_input.extend_from_slice(b);
     }
-    for (i, &idx) in indices.iter().enumerate() { 
+    for (_i, &idx) in indices.iter().enumerate() { 
       fs_input.extend_from_slice(&idx.to_le_bytes()); 
     }
     
@@ -1642,7 +1639,7 @@ pub fn verify_multiple(
     let mut acc_pow = big::BIG::new_int(1);
     let mut y = big::BIG::new();
     
-    for ((c_i, y_i), &idx) in c_points.iter().zip(y_scalars.iter()).zip(indices) {
+    for ((_c_i, y_i), &idx) in c_points.iter().zip(y_scalars.iter()).zip(indices) {
         let z_i = bls::singleton().RootsOfUnityBLS48581[&poly_size][idx as usize].clone();
         
         let mut denom = big::BIG::modadd(&t, &big::BIG::modneg(&z_i, &modulus), &modulus);

--- a/crates/bls48581/src/lib.rs
+++ b/crates/bls48581/src/lib.rs
@@ -51,7 +51,6 @@ fn recurse_fft(
     fft_width: u64,
     inverse: bool,
 ) {
-  let _M = &big::BIG::new_ints(&rom::CURVE_ORDER);
   let roots = if inverse {
     &bls::singleton().ReverseRootsOfUnityBLS48581[&fft_width]
   } else {
@@ -1467,17 +1466,17 @@ pub fn prove_multiple(
 
     // 1. Fiat–Shamir challenge  ρ
     let mut fs_input = Vec::<u8>::new();
-    for (_i, c) in commits.iter().enumerate() {
+    for c in commits.iter() {
         let mut tmp = [0u8; 74];
         c.tobytes(&mut tmp, true);
         fs_input.extend_from_slice(&tmp);
     }
-    for (_i, s) in y.iter().enumerate() {
+    for s in y.iter() {
         let mut tmp = [0u8; 73];
         s.tobytes(&mut tmp);
         fs_input.extend_from_slice(&tmp);
     }
-    for (_i, &idx) in indices.iter().enumerate() { 
+    for &idx in indices.iter() { 
         fs_input.extend_from_slice(&idx.to_le_bytes()); 
     }
     let rho = hash_to_scalar(&fs_input);
@@ -1533,12 +1532,12 @@ pub fn prove_multiple(
 
     // 5. Compute h(x) =  Σ ρᶦ · (fᵢ(X))/(t − zᵢ)
     let mut acc_pow = big::BIG::new_int(1);
-    for ((index, _blob), (&idx, _y_i)) in polys.iter().enumerate().zip(indices.iter().zip(y.iter())) {
+    for ((index, _), (&idx, _)) in polys.iter().enumerate().zip(indices.iter().zip(y.iter())) {
         let mut coeffs = f_evals[index].clone();
         let z_i = bls::singleton().RootsOfUnityBLS48581[&poly_size][idx as usize].clone();
         let mut den = big::BIG::modadd(&t, &big::BIG::modneg(&z_i, &modulus), &modulus);
         den.invmodp(&modulus);
-        for (_i, dst) in coeffs.iter_mut().enumerate() {
+        for dst in coeffs.iter_mut() {
           *dst = big::BIG::modmul(dst, &acc_pow, &modulus);
           *dst = big::BIG::modmul(dst, &den, &modulus);
         }
@@ -1611,21 +1610,21 @@ pub fn verify_multiple(
 
     let mut c_points: Vec<ecp::ECP> = Vec::with_capacity(m); // Cᵢ
     let mut y_scalars: Vec<big::BIG> = Vec::with_capacity(m); // yᵢ
-    for (_i, (c_bytes, y_b)) in commits.iter().zip(y_bytes).enumerate() {
+    for (c_bytes, y_b) in commits.iter().zip(y_bytes) {
         c_points.push(ecp::ECP::frombytes(&c_bytes));
         y_scalars.push(big::BIG::frombytes(&y_b));
     }
 
     // 1. Re‑derive ρ
     let mut fs_input = Vec::<u8>::new();
-    for (_i, b) in commits.iter().enumerate() {
+    for b in commits.iter() {
       fs_input.extend_from_slice(b);
     }
-    for (_i, b) in y_bytes.iter().enumerate() {
+    for b in y_bytes.iter() {
       fs_input.extend_from_slice(&[0u8;9]);
       fs_input.extend_from_slice(b);
     }
-    for (_i, &idx) in indices.iter().enumerate() { 
+    for &idx in indices.iter() { 
       fs_input.extend_from_slice(&idx.to_le_bytes()); 
     }
     
@@ -1639,7 +1638,7 @@ pub fn verify_multiple(
     let mut acc_pow = big::BIG::new_int(1);
     let mut y = big::BIG::new();
     
-    for ((_c_i, y_i), &idx) in c_points.iter().zip(y_scalars.iter()).zip(indices) {
+    for ((_, y_i), &idx) in c_points.iter().zip(y_scalars.iter()).zip(indices) {
         let z_i = bls::singleton().RootsOfUnityBLS48581[&poly_size][idx as usize].clone();
         
         let mut denom = big::BIG::modadd(&t, &big::BIG::modneg(&z_i, &modulus), &modulus);

--- a/crates/bulletproofs-wasm/src/lib.rs
+++ b/crates/bulletproofs-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use wasm_bindgen::prelude::*;
-use bulletproofs::{generate_input_commitments, generate_range_proof, verify_range_proof, sum_check, scalar_mult_point, scalar_mult, scalar_inverse, keygen, scalar_mult_hash_to_scalar, hash_to_scalar, scalar_addition, scalar_subtraction, scalar_to_point, alt_generator, point_addition, point_subtraction, sign_hidden, verify_hidden, sign_simple, verify_simple, RangeProofResult};
+use bulletproofs::{generate_input_commitments, generate_range_proof, verify_range_proof, sum_check, scalar_mult_point, scalar_mult, scalar_inverse, keygen, scalar_mult_hash_to_scalar, hash_to_scalar, scalar_addition, scalar_subtraction, scalar_to_point, alt_generator, point_addition, point_subtraction, sign_hidden, verify_hidden, sign_simple, verify_simple};
 
 // Bulletproofs wrapper functions
 

--- a/crates/channel-wasm/src/lib.rs
+++ b/crates/channel-wasm/src/lib.rs
@@ -636,10 +636,7 @@ pub fn js_verify_point(params: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
-    use ed448_goldilocks_plus::{Scalar, elliptic_curve::Group, EdwardsPoint};
 
     #[test]
     fn test_verify() {    

--- a/crates/channel/benches/bench_channel.rs
+++ b/crates/channel/benches/bench_channel.rs
@@ -1,7 +1,6 @@
-use rand::Rng;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
-fn criterion_benchmark(c: &mut Criterion) {
+fn criterion_benchmark(_c: &mut Criterion) {
 
 }
 

--- a/crates/channel/src/lib.rs
+++ b/crates/channel/src/lib.rs
@@ -684,7 +684,7 @@ pub fn new_triple_ratchet(peers: &Vec<Vec<u8>>, peer_key: &Vec<u8>, identity_key
     };
 }
 
-fn metadata_to_json(ratchet_state: &String, metadata: HashMap<Vec<u8>, P2PChannelEnvelope>) -> Result<HashMap<String, String>, TripleRatchetStateAndMetadata> {
+fn metadata_to_json(_ratchet_state: &String, metadata: HashMap<Vec<u8>, P2PChannelEnvelope>) -> Result<HashMap<String, String>, TripleRatchetStateAndMetadata> {
     let mut metadata_json = HashMap::<String, String>::new();
     for (k,v) in metadata {
         let env = v.to_json();

--- a/crates/channel/src/protocols/doubleratchet.rs
+++ b/crates/channel/src/protocols/doubleratchet.rs
@@ -9,7 +9,6 @@ use hkdf::Hkdf;
 use aes_gcm::{Aes256Gcm, Nonce};
 use aes_gcm::aead::{Aead, Payload};
 use std::collections::HashMap;
-use std::error;
 use subtle::ConstantTimeEq;
 use serde::{Serialize, Deserialize};
 

--- a/crates/channel/src/protocols/feldman.rs
+++ b/crates/channel/src/protocols/feldman.rs
@@ -1,9 +1,9 @@
 use base64::prelude::*;
-use std::{collections::HashMap, io::Read};
+use std::collections::HashMap;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
-use ed448_goldilocks_plus::{elliptic_curve::{group::GroupEncoding, Field, Group}, subtle::ConstantTimeEq, EdwardsPoint, Scalar};
+use ed448_goldilocks_plus::{elliptic_curve::{group::GroupEncoding, Group}, subtle::ConstantTimeEq, EdwardsPoint, Scalar};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/crates/channel/src/protocols/tripleratchet.rs
+++ b/crates/channel/src/protocols/tripleratchet.rs
@@ -956,7 +956,12 @@ impl TripleRatchetParticipant {
           },
           Err(_) if receiving_header_key == self.current_header_key => {
               if self.async_dkg_ratchet && self.async_dkg_pubkey.is_some() {
-                  let _receiving_group_key = Some(self.dkg_ratchet.public_key().to_bytes().to_vec());
+                  // This only derives the header key to *try* the decrypt; the
+                  // matching state update (`receiving_group_key`, `root_key`,
+                  // `current_header_key`, `next_header_key`) is performed by
+                  // `advance_and_decrypt` when we return
+                  // `should_advance_dkg_ratchet = true` below. Do not assign
+                  // `self.receiving_group_key` here as well.
                   let sess = Sha512::digest(&self.dkg_ratchet.public_key_bytes());
                   let hkdf = Hkdf::<Sha512>::new(
                       Some(&sess),

--- a/crates/channel/src/protocols/tripleratchet.rs
+++ b/crates/channel/src/protocols/tripleratchet.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use ed448_goldilocks_plus::elliptic_curve::group::GroupEncoding;
 use ed448_goldilocks_plus::elliptic_curve::Group;
 use rand::rngs::OsRng;
-use rand::{CryptoRng, RngCore};
+use rand::RngCore;
 use sha2::{Sha512, Digest};
 use hkdf::Hkdf;
 use aes_gcm::{Aes256Gcm, Nonce};
@@ -14,7 +14,7 @@ use thiserror::Error;
 use subtle::ConstantTimeEq;
 use super::doubleratchet::{MAX_SKIP, MAX_SKIPPED_KEYS};
 
-use super::doubleratchet::{DoubleRatchetParticipant, DoubleRatchetParticipantJson, MessageCiphertext, P2PChannelEnvelope};
+use super::doubleratchet::{DoubleRatchetParticipant, MessageCiphertext, P2PChannelEnvelope};
 use super::feldman::{Feldman, vec_to_array, FeldmanReveal, FeldmanFrag};
 use super::x3dh::{receiver_x3dh, sender_x3dh};
 
@@ -956,7 +956,7 @@ impl TripleRatchetParticipant {
           },
           Err(_) if receiving_header_key == self.current_header_key => {
               if self.async_dkg_ratchet && self.async_dkg_pubkey.is_some() {
-                  let receiving_group_key = Some(self.dkg_ratchet.public_key().to_bytes().to_vec());
+                  let _receiving_group_key = Some(self.dkg_ratchet.public_key().to_bytes().to_vec());
                   let sess = Sha512::digest(&self.dkg_ratchet.public_key_bytes());
                   let hkdf = Hkdf::<Sha512>::new(
                       Some(&sess),

--- a/crates/channel/src/protocols/x3dh.rs
+++ b/crates/channel/src/protocols/x3dh.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use sha2::Sha512;
 use hkdf::Hkdf;
-use ed448_goldilocks_plus::{subtle, CompressedEdwardsY, EdwardsPoint, Scalar};
+use ed448_goldilocks_plus::{EdwardsPoint, Scalar};
 use lazy_static::lazy_static;
 
 lazy_static! {

--- a/crates/ferret/build.rs
+++ b/crates/ferret/build.rs
@@ -1,7 +1,6 @@
 // build.rs
 use cc;
 use std::env;
-use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
@@ -113,7 +112,7 @@ fn main() {
     println!("cargo:rerun-if-changed=emp_bridge.cpp");
     println!("cargo:rerun-if-changed=emp_bridge.h");
   } else {
-    panic!("unsupported target {target}");
+    panic!("unsupported target {}", target);
   }
   uniffi::generate_scaffolding("src/lib.udl").expect("uniffi generation failed");
 }
@@ -136,12 +135,13 @@ fn resolve_lib_root(pkg: &str, env_var: &str) -> String {
     match out {
         Ok(o) if o.status.success() => {
             let s = String::from_utf8(o.stdout)
-                .unwrap_or_else(|e| panic!("brew --prefix {pkg}: utf8 decode failed: {e}"));
+                .unwrap_or_else(|e| panic!("brew --prefix {pkg}: utf8 decode failed: {}", e));
             let trimmed = s.trim();
             if trimmed.is_empty() {
                 panic!(
-                    "brew --prefix {pkg} returned empty; install with `brew install {pkg}` \
-                     or set {env_var} to the install root"
+                    "brew --prefix {} returned empty; install with `brew install {pkg}` \
+                     or set {env_var} to the install root",
+                    pkg
                 );
             }
             trimmed.to_string()
@@ -153,8 +153,9 @@ fn resolve_lib_root(pkg: &str, env_var: &str) -> String {
             String::from_utf8_lossy(&o.stderr).trim()
         ),
         Err(e) => panic!(
-            "could not invoke `brew --prefix {pkg}`: {e}; install Homebrew and run \
-             `brew install {pkg}`, or set {env_var} to the install root"
+            "could not invoke `brew --prefix {pkg}`: {}; install Homebrew and run \
+             `brew install {pkg}`, or set {env_var} to the install root",
+            e
         ),
     }
 }

--- a/crates/ferret/examples/simple_ot.rs
+++ b/crates/ferret/examples/simple_ot.rs
@@ -1,4 +1,4 @@
-use ferret::{NetIO, FerretCOT, BlockArray, ALICE, BOB};
+use ferret::{NetIO, FerretCOT, BlockArray, ALICE};
 use std::env;
 
 fn main() {

--- a/crates/ferret/src/lib.rs
+++ b/crates/ferret/src/lib.rs
@@ -3,9 +3,7 @@
 use core::fmt;
 use std::error::Error;
 use std::ffi::CString;
-use std::os::raw::{c_char, c_void, c_int};
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaCha20Rng;
+use std::os::raw::{c_char, c_int};
 use std::sync::{Arc, Mutex};
 
 

--- a/crates/vdf/src/lib.rs
+++ b/crates/vdf/src/lib.rs
@@ -272,7 +272,7 @@ pub fn wesolowski_solve_multi(
   ids: &Vec<Vec<u8>>,
   i: u32,
 ) -> Vec<u8> {
-  use classgroup::{gmp_classgroup::GmpClassGroup, BigNumExt, ClassGroup};
+  use classgroup::{gmp_classgroup::GmpClassGroup, ClassGroup};
   use crate::proof_of_time::serialize;
   use crate::proof_wesolowski::{commit_ids, hash_prime_fixed, worker_prove_id_bound};
 
@@ -354,7 +354,7 @@ pub fn wesolowski_verify_multi_sparse(
   present_ids: &Vec<Vec<u8>>,
   alleged_solutions: &Vec<Vec<u8>>,
 ) -> bool {
-  use classgroup::{gmp_classgroup::GmpClassGroup, BigNum, BigNumExt, ClassGroup};
+  use classgroup::{gmp_classgroup::GmpClassGroup, BigNum, ClassGroup};
   use crate::proof_wesolowski::{commit_ids, hash_prime_fixed, hash_to_exponent};
 
   // Basic shape checks. `present_ids` is parallel to the solutions; the
@@ -477,7 +477,8 @@ mod multiproof_bench {
                 .collect();
             assert!(
                 wesolowski_verify_multi(int_size_bits, challenge, difficulty, &id_set, &blobs),
-                "N={n} honest proofs must verify"
+                "N={} honest proofs must verify",
+                n
             );
             let iters = 20u32;
             let start = Instant::now();

--- a/crates/verenc-wasm/src/lib.rs
+++ b/crates/verenc-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use wasm_bindgen::prelude::*;
-use verenc::{new_verenc_proof, new_verenc_proof_encrypt_only, verenc_verify, verenc_compress, verenc_recover, chunk_data_for_verenc, combine_chunked_data, verenc_verify_statement, VerencProofAndBlindingKey, VerencProof, CompressedCiphertext, VerencDecrypt, VerencCiphertext, VerencShare};
+use verenc::{new_verenc_proof, new_verenc_proof_encrypt_only, verenc_verify, verenc_compress, verenc_recover, chunk_data_for_verenc, combine_chunked_data, verenc_verify_statement, VerencProof, CompressedCiphertext, VerencDecrypt, VerencCiphertext, VerencShare};
 
 // Create a new verifiable encryption proof
 #[wasm_bindgen]

--- a/crates/verenc/src/lib.rs
+++ b/crates/verenc/src/lib.rs
@@ -435,7 +435,7 @@ pub fn verenc_recover(recovery: VerencDecrypt) -> Vec<u8> {
     let pke = Elgamal::setup(&params);
     let (N, t, n) = RVE_PARAMS[0];
     let vparams = RDkgithParams{ N, t, n };
-    let mut ve = RDkgith::setup(&params, &vparams, pke.clone());
+    let ve = RDkgith::setup(&params, &vparams, pke.clone());
     let wit_recover = ve.recover(&statement.unwrap(), &decryption_key, &ve_ct);
     return wit_recover.to_bytes().to_vec();
 }
@@ -497,7 +497,7 @@ mod tests {
         OsRng::fill_bytes(&mut OsRng, &mut roundcheck);
         let rndch = chunk_data_for_verenc(roundcheck.to_vec());
         assert!(rndch.len() == 24);
-        for i in 0..1000 {
+        for _i in 0..1000 {
             let mut data: [u8; 1265] = [0u8;1265];
             OsRng::fill_bytes(&mut OsRng, &mut data);
             let chunks = chunk_data_for_verenc(data.to_vec());


### PR DESCRIPTION
The same mechanical class as #598 but in `bls48581`, `channel`, `ferret`,
`vdf`, `verenc` and the four wasm wrappers — **46 warnings** — **plus five
`non_fmt_panics` that are real message bugs.**

`ferret` and `vdf` are edition 2018, where a single-argument `panic!` takes the
string verbatim. So `panic!("unsupported target {target}")` prints the literal
`{target}` rather than the value — the panic message that is supposed to tell you
which target failed does not.

Worth flagging: `cargo fix`'s suggestion for this lint is
`panic!("{}", "unsupported target {target}")`, which silences the warning and
**keeps** the broken output. These are fixed with explicit format arguments
instead, so the messages actually interpolate.

### Two changes since this was first pushed

- **`channel-wasm` is now in scope** (+2). Its two dead `use` items sit in a
  `#[cfg(test)]` module and the audit command excluded the crate, so they were
  never listed. With the rest of the series applied they were the last two
  warnings in the workspace.
- **One warning moved to #602** (−1). `json_to_metadata`'s unused
  `ratchet_state` parameter is renamed there instead of here, so that the whole
  of that dead function — annotation, comment and parameter — is described by a
  single PR. Previously the two PRs touched adjacent lines of the same signature
  and conflicted on whichever merged second; they now merge in either order and
  produce an identical tree. The warning is still fixed exactly once across the
  series. `metadata_to_json`, which is live, keeps its rename here.

---

### Series

Part of the warning-cleanup series that starts with **#597**. The eight PRs are
disjoint and each stands on its own, but they are meant to be read in order —
**please take #597 first**: it is the only one of the eight that fixes a bug
rather than a warning, and it is the shortest.

- **Base:** `932045a3`
- **Verified with all eight applied:** the workspace goes from **309 warnings to 16** —
  the 16 being `classgroup`'s GMP FFI glue, deliberately left visible rather than
  silenced. **Update:** those 16 are now fixed rather than documented, in #605,
  which corrects the declarations and the uninitialized values instead of
  annotating them. With #605 and the channelwasm commit in this PR, the combined tree
  checks with **zero** warnings.
- To check this PR on its own:
  ```
  cargo check --keep-going --workspace --lib --bins --tests --examples
  ```
  (The earlier form of this command carried `--exclude channelwasm`. That crate
  is in scope now — it is the last commit here — so the exclusion is gone.)

Happy to re-pace these, drop any of them, or squash the set into a single PR if
you would rather review it in one pass — just say which.

Drafted with Claude Code; every site was read individually and the reasoning is
in the commit message.


