### PR TITLE
chore: scope the naming lints in the crypto crates to the FFI/ported names

### DIFF
--- a/crates/bls48581/src/bls.rs
+++ b/crates/bls48581/src/bls.rs
@@ -8,6 +8,10 @@ use crate::bls48581::ecp;
 use crate::bls48581::ecp8;
 use crate::bls48581::bls256;
 
+// Field names mirror the Go ceremonyclient's KZG setup (`RootOfUnityBLS48581`,
+// `CeremonyBLS48581G1`, ...) and are read by name across the workspace, so they
+// keep the original casing rather than being renamed to snake case.
+#[allow(non_snake_case)]
 pub struct SingletonKZGSetup {
   pub RootOfUnityBLS48581: HashMap<u64, big::BIG>,
   pub RootsOfUnityBLS48581: HashMap<u64, Vec<big::BIG>>,
@@ -17,6 +21,10 @@ pub struct SingletonKZGSetup {
   pub FFTBLS48581: HashMap<u64, Vec<ecp::ECP>>,
 }
 
+// Locals mirror the `optimized_ceremony.json` keys they are loaded from
+// (`rootsOfUnity32`, `reverseRootsOfUnity`, ...), so the parsing code reads
+// the same as the file it parses.
+#[allow(non_snake_case)]
 pub fn singleton() -> &'static SingletonKZGSetup {
   static mut SINGLETON: MaybeUninit<SingletonKZGSetup> = MaybeUninit::uninit();
   static ONCE: Once = Once::new();

--- a/crates/bls48581/src/lib.rs
+++ b/crates/bls48581/src/lib.rs
@@ -45,6 +45,8 @@ use ::rand::RngCore;
 
 uniffi::include_scaffolding!("lib");
 
+// `M` is the modulus in the FFT recurrence, named as in the KZG literature.
+#[allow(non_snake_case)]
 fn recurse_fft(
     values: &[big::BIG],
     offset: u64,
@@ -1707,11 +1709,11 @@ mod tests {
           let sig = bls_sign(&out.secret_key, b"test msg", b"test domain");
           sigs.push(sig);
         }
-        let blsAggregateOutput = bls_aggregate(
+        let bls_aggregate_output = bls_aggregate(
           &outs.iter().map(|out| out.public_key.clone()).collect::<Vec<Vec<u8>>>(),
           &sigs,
         );
-        assert!(bls_verify(&blsAggregateOutput.aggregate_public_key, &blsAggregateOutput.aggregate_signature, b"test msg", b"test domain"));
+        assert!(bls_verify(&bls_aggregate_output.aggregate_public_key, &bls_aggregate_output.aggregate_signature, b"test msg", b"test domain"));
     }
 
     #[test]
@@ -1759,11 +1761,11 @@ mod tests {
           messages.push(msg.as_bytes().to_vec());
           sigs.push(sig);
         }
-        let blsAggregateOutput = bls_aggregate(
+        let bls_aggregate_output = bls_aggregate(
           &outs.iter().map(|out| out.public_key.clone()).collect::<Vec<Vec<u8>>>(),
           &sigs,
         );
-        assert!(bls_verify_msig_mmsg(&pks, &blsAggregateOutput.aggregate_signature, &messages, b"test domain"));
+        assert!(bls_verify_msig_mmsg(&pks, &bls_aggregate_output.aggregate_signature, &messages, b"test domain"));
     }
 
     #[test]

--- a/crates/ferret/src/lib.rs
+++ b/crates/ferret/src/lib.rs
@@ -22,16 +22,28 @@ impl fmt::Display for FerretError {
 
 impl Error for FerretError {}
 
-// Opaque pointer types
+// Opaque pointer types. Each name mirrors the C typedef it stands in for, so
+// the `extern "C"` block below can be diffed line-for-line against
+// emp_bridge.h; renaming them to Rust camel case would break that reading.
+#[allow(non_camel_case_types)]
 pub enum NetIO_t {}
+#[allow(non_camel_case_types)]
 pub enum BufferIO_t {}
+#[allow(non_camel_case_types)]
 pub enum FerretCOT_t {}
+#[allow(non_camel_case_types)]
 pub enum FerretCOT_Buffer_t {}
+#[allow(non_camel_case_types)]
 pub enum block_t {}
+#[allow(non_camel_case_types)]
 pub type NetIO_ptr = *mut NetIO_t;
+#[allow(non_camel_case_types)]
 pub type BufferIO_ptr = *mut BufferIO_t;
+#[allow(non_camel_case_types)]
 pub type FerretCOT_ptr = *mut FerretCOT_t;
+#[allow(non_camel_case_types)]
 pub type FerretCOT_Buffer_ptr = *mut FerretCOT_Buffer_t;
+#[allow(non_camel_case_types)]
 pub type block_ptr = *mut block_t;
 
 // Constants

--- a/crates/vdf/src/proof_wesolowski.rs
+++ b/crates/vdf/src/proof_wesolowski.rs
@@ -520,22 +520,22 @@ where
   let mut r = TN::from(0);
   r.mod_powm(&TN::from(2u64), &TN::from(iterations), &b);
 
-  // S = sum_i h_i
-  let mut S = TN::from(0);
+  // s_sum = sum_i h_i
+  let mut s_sum = TN::from(0);
   for id in ids {
       let hi = hash_to_exponent::<TN>(challenge, id.as_ref());
-      S = S + hi;
+      s_sum = s_sum + hi;
   }
 
   // lhs = pi_agg^b * x^{ r * S }
   let mut lhs = pi_agg.clone();
   lhs.pow(b.clone());
 
-  let rS = r * S;
-  let mut xrS = x.clone();
-  xrS.pow(rS);
+  let r_s = r * s_sum;
+  let mut x_rs = x.clone();
+  x_rs.pow(r_s);
 
-  lhs *= &xrS;
+  lhs *= &x_rs;
 
   if &lhs == y_agg { Ok(()) } else { Err(()) }
 }

--- a/crates/verenc/src/lib.rs
+++ b/crates/verenc/src/lib.rs
@@ -73,6 +73,9 @@ pub struct CompressedCiphertext {
     pub aux: Vec<Vec<u8>>,
 }
 
+// `N` shadows the `RDkgithParams::N` field it is assigned to; keeping the
+// casing lets the struct literal below stay field-shorthand.
+#[allow(non_snake_case)]
 pub fn new_verenc_proof(data: Vec<u8>) -> VerencProofAndBlindingKey {
     if data.len() != 56 {
         return VerencProofAndBlindingKey{
@@ -120,6 +123,9 @@ pub fn new_verenc_proof(data: Vec<u8>) -> VerencProofAndBlindingKey {
     };
 }
 
+// `N` shadows the `RDkgithParams::N` field it is assigned to; keeping the
+// casing lets the struct literal below stay field-shorthand.
+#[allow(non_snake_case)]
 pub fn new_verenc_proof_encrypt_only(data: Vec<u8>, encryption_key_bytes: Vec<u8>) -> VerencProofAndBlindingKey {
     if data.len() != 56 {
         return VerencProofAndBlindingKey{
@@ -207,6 +213,9 @@ fn point_from_bytes(bytes: Vec<u8>) -> Option<EdwardsPoint> {
     return Some(key.unwrap());
 }
 
+// `N` shadows the `RDkgithParams::N` field it is assigned to; keeping the
+// casing lets the struct literal below stay field-shorthand.
+#[allow(non_snake_case)]
 pub fn verenc_verify(proof: VerencProof) -> bool {
     let blinding_key = point_from_bytes(proof.blinding_pubkey);
     if blinding_key.is_none() {
@@ -281,6 +290,9 @@ pub fn verenc_verify(proof: VerencProof) -> bool {
 }
 
 
+// `N` shadows the `RDkgithParams::N` field it is assigned to; keeping the
+// casing lets the struct literal below stay field-shorthand.
+#[allow(non_snake_case)]
 pub fn verenc_compress(proof: VerencProof) -> CompressedCiphertext {
     let blinding_key = point_from_bytes(proof.blinding_pubkey);
     if blinding_key.is_none() {
@@ -385,6 +397,9 @@ pub fn verenc_compress(proof: VerencProof) -> CompressedCiphertext {
     };
 }
 
+// `N` shadows the `RDkgithParams::N` field it is assigned to; keeping the
+// casing lets the struct literal below stay field-shorthand.
+#[allow(non_snake_case)]
 pub fn verenc_recover(recovery: VerencDecrypt) -> Vec<u8> {
     let blinding_key = point_from_bytes(recovery.blinding_pubkey);
     if blinding_key.is_none() {


### PR DESCRIPTION
`non_snake_case` / `non_camel_case_types` where the name deliberately mirrors
something external — **35 warnings**:

- `bls48581`'s KZG setup fields and the `optimized_ceremony.json` keys they parse
- `ferret`'s ten opaque pointer types, which mirror `emp_bridge.h`
- `verenc`'s `N`, which mirrors `RDkgithParams::N`

Each allow sits on the narrowest item that works and carries a comment naming
what it mirrors, so the constraint is visible to the next reader rather than
implied.

Two sites are renamed instead, where nothing external depended on the casing:
`bls48581`'s test-only `blsAggregateOutput`, and the locals in
`vdf::proof_wesolowski::verify_aggregated`.

---

### Series

Part of the warning-cleanup series that starts with **#597**. The eight PRs are
disjoint and each stands on its own, but they are meant to be read in order —
**please take #597 first**: it is the only one of the eight that fixes a bug
rather than a warning, and it is the shortest.

- **Base:** `932045a3`
- **Verified with all eight applied:** the workspace goes from **309 warnings to 16** —
  the 16 being `classgroup`'s GMP FFI glue, deliberately left visible rather than
  silenced. **Update:** those 16 are now fixed rather than documented, in #605,
  which corrects the declarations and the uninitialized values instead of
  annotating them. With #605 and the channelwasm commit in #599, the combined
  tree checks with **zero** warnings.
- To check this PR on its own:
  ```
  cargo check --keep-going --workspace --lib --bins --tests --examples
  ```
  (The earlier form of this command carried `--exclude channelwasm`. That crate
  is in scope now — #599 covers it — so the exclusion is gone.)

Happy to re-pace these, drop any of them, or squash the set into a single PR if
you would rather review it in one pass — just say which.

Drafted with Claude Code; every site was read individually and the reasoning is
in the commit message.


