### PR TITLE
chore: scope the deprecated-field lint to the wire-compat sites that need it

### DIFF
--- a/crates/quil-client/src/commands/node/prover/ops.rs
+++ b/crates/quil-client/src/commands/node/prover/ops.rs
@@ -55,6 +55,11 @@ pub async fn leave(pc: &ProverCtx, filter_args: &[String]) -> anyhow::Result<()>
     Ok(())
 }
 
+// `filter` is deprecated in global.proto in favour of the repeated `filters`,
+// but it is still on the wire: peers that predate the change send it, and
+// dropping it here would change the encoded bytes. Carried through verbatim
+// until the field is retired from the proto.
+#[allow(deprecated)]
 pub async fn confirm(pc: &ProverCtx, filter_args: &[String]) -> anyhow::Result<()> {
     let filters = parse_filters(filter_args)?;
     let mut client = pc.connect().await?;
@@ -72,6 +77,7 @@ pub async fn confirm(pc: &ProverCtx, filter_args: &[String]) -> anyhow::Result<(
     Ok(())
 }
 
+#[allow(deprecated)] // see `confirm`
 pub async fn reject(pc: &ProverCtx, filter_args: &[String]) -> anyhow::Result<()> {
     let filters = parse_filters(filter_args)?;
     let mut client = pc.connect().await?;

--- a/crates/quil-execution/src/global_intrinsic/conversions.rs
+++ b/crates/quil-execution/src/global_intrinsic/conversions.rs
@@ -350,6 +350,11 @@ pub fn prover_resume_to_proto(r: &ProverResume) -> pb::ProverResume {
 // ProverConfirm/Reject ↔ proto
 // =====================================================================
 
+// `filter` is deprecated in global.proto in favour of the repeated `filters`,
+// but it is still on the wire: peers that predate the change send it, and
+// dropping it here would change the encoded bytes. Carried through verbatim
+// until the field is retired from the proto.
+#[allow(deprecated)]
 pub fn prover_confirm_from_proto(pb: &pb::ProverConfirm) -> ProverConfirm {
     ProverConfirm {
         filter: pb.filter.clone(),
@@ -363,6 +368,7 @@ pub fn prover_confirm_from_proto(pb: &pb::ProverConfirm) -> ProverConfirm {
     }
 }
 
+#[allow(deprecated)] // see `prover_confirm_from_proto`
 pub fn prover_confirm_to_proto(c: &ProverConfirm) -> pb::ProverConfirm {
     pb::ProverConfirm {
         filter: c.filter.clone(),
@@ -410,6 +416,7 @@ fn confirm_leaf_roots_to_proto(
     }
 }
 
+#[allow(deprecated)] // see `prover_confirm_from_proto`
 pub fn prover_reject_from_proto(pb: &pb::ProverReject) -> ProverReject {
     ProverReject {
         filter: pb.filter.clone(),
@@ -422,6 +429,7 @@ pub fn prover_reject_from_proto(pb: &pb::ProverReject) -> ProverReject {
     }
 }
 
+#[allow(deprecated)] // see `prover_confirm_from_proto`
 pub fn prover_reject_to_proto(r: &ProverReject) -> pb::ProverReject {
     pb::ProverReject {
         filter: r.filter.clone(),
@@ -552,6 +560,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // deprecated `filter` is part of what round-trips
     fn prover_confirm_round_trip() {
         let pb = pb::ProverConfirm {
             filter: vec![0x44u8; 32],
@@ -566,6 +575,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // deprecated `filter` is part of what round-trips
     fn prover_reject_round_trip() {
         let pb = pb::ProverReject {
             filter: vec![],

--- a/crates/quil-execution/src/message_envelope.rs
+++ b/crates/quil-execution/src/message_envelope.rs
@@ -397,6 +397,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // the fixture sets the deprecated `filter` explicitly
     fn proto_to_canonical_confirm_matches_handcrafted() {
         use quil_types::proto::global as pb;
         use quil_types::proto::keys as keys_pb;

--- a/crates/quil-rpc/tests/cross_language_signing.rs
+++ b/crates/quil-rpc/tests/cross_language_signing.rs
@@ -63,6 +63,11 @@ fn build_leave() -> pb::MessageBundle {
     bundle_with(pb::message_request::Request::Leave(leave))
 }
 
+// `filter` is deprecated in global.proto in favour of the repeated `filters`,
+// but it is still on the wire: peers that predate the change send it, and
+// dropping it here would change the encoded bytes. Carried through verbatim
+// until the field is retired from the proto.
+#[allow(deprecated)]
 fn build_confirm() -> pb::MessageBundle {
     let confirm = pb::ProverConfirm {
         filter: vec![],
@@ -74,6 +79,7 @@ fn build_confirm() -> pb::MessageBundle {
     bundle_with(pb::message_request::Request::Confirm(confirm))
 }
 
+#[allow(deprecated)] // see `build_confirm`
 fn build_reject() -> pb::MessageBundle {
     let reject = pb::ProverReject {
         filter: vec![],


### PR DESCRIPTION
`global.proto` deprecates `ProverConfirm.filter` and `ProverReject.filter` in
favour of the repeated `filters` — **11 warnings**.

The field cannot just be dropped. It is still on the wire from peers that predate
the change, and `prover_confirm_to_proto` / `prover_reject_to_proto` are expected
to reproduce their input byte-for-byte — the round-trip tests assert exactly
that. Removing the reads would silently change the encoding, and the signing
payload derived from it.

So this is `#[allow(deprecated)]` on the eight functions that legitimately touch
the field, each carrying the wire-compat reason. Any *new* use still warns, and
when the field is finally retired these allows are the checklist of call sites to
delete.

---

### Series

Part of the warning-cleanup series that starts with **#597**. The eight PRs are
disjoint and each stands on its own, but they are meant to be read in order —
**please take #597 first**: it is the only one of the eight that fixes a bug
rather than a warning, and it is the shortest.

- **Base:** `932045a3`
- **Verified with all eight applied:** the workspace goes from **309 warnings to 16** —
  the 16 being `classgroup`'s GMP FFI glue, deliberately left visible rather than
  silenced. **Update:** those 16 are now fixed rather than documented, in #605,
  which corrects the declarations and the uninitialized values instead of
  annotating them. With #605 and the channelwasm commit in #599, the combined
  tree checks with **zero** warnings.
- To check this PR on its own:
  ```
  cargo check --keep-going --workspace --lib --bins --tests --examples
  ```
  (The earlier form of this command carried `--exclude channelwasm`. That crate
  is in scope now — #599 covers it — so the exclusion is gone.)

Happy to re-pace these, drop any of them, or squash the set into a single PR if
you would rather review it in one pass — just say which.

Drafted with Claude Code; every site was read individually and the reasoning is
in the commit message.


