### PR TITLE
chore: replace the unsound static-mut and ignored-Result patterns

### DIFF
--- a/crates/bls48581/src/bls.rs
+++ b/crates/bls48581/src/bls.rs
@@ -1,5 +1,4 @@
-use std::sync::{Once};
-use std::{mem::MaybeUninit};
+use std::sync::OnceLock;
 use std::collections::HashMap;
 use serde_json;
 use hex;
@@ -18,11 +17,9 @@ pub struct SingletonKZGSetup {
 }
 
 pub fn singleton() -> &'static SingletonKZGSetup {
-  static mut SINGLETON: MaybeUninit<SingletonKZGSetup> = MaybeUninit::uninit();
-  static ONCE: Once = Once::new();
+  static SINGLETON: OnceLock<SingletonKZGSetup> = OnceLock::new();
 
-  unsafe {
-    ONCE.call_once(|| {
+  SINGLETON.get_or_init(|| {
       bls256::init();
       let bytes = include_bytes!("optimized_ceremony.json");
       let v: serde_json::Value = serde_json::from_slice(bytes).unwrap();
@@ -232,18 +229,13 @@ pub fn singleton() -> &'static SingletonKZGSetup {
       // }
       // ffts.insert(65536, f65536);
 
-      let singleton = SingletonKZGSetup {
+      SingletonKZGSetup {
         RootOfUnityBLS48581: rootOfUnity,
         RootsOfUnityBLS48581: rootsOfUnity,
         ReverseRootsOfUnityBLS48581: reverseRootsOfUnity,
         CeremonyBLS48581G1: blsg1,
         CeremonyBLS48581G2: blsg2,
         FFTBLS48581: ffts,
-      };
-
-      SINGLETON.write(singleton);
-    });
-
-    SINGLETON.assume_init_ref()
-  }
+      }
+  })
 }

--- a/crates/bls48581/src/bls48581/bls256.rs
+++ b/crates/bls48581/src/bls48581/bls256.rs
@@ -27,6 +27,7 @@ use crate::bls48581::fp16::FP16;
 use crate::bls48581::pair8;
 use crate::bls48581::rom;
 use crate::hmac;
+use std::sync::OnceLock;
 
 /* Boneh-Lynn-Shacham signature 256-bit API Functions */
 
@@ -37,7 +38,10 @@ pub const BLS_FAIL: isize = -1;
 
 // NOTE this must be accessed in unsafe mode.
 // But it is just written to once at start-up, so actually safe.
-static mut G2_TAB: [FP16; ecp::G2_TABLE] = [FP16::new(); ecp::G2_TABLE];
+/// Precomputed pairing table for the G2 generator. Filled exactly once by
+/// `init()`; every reader below goes through `expect`, so a missing `init()`
+/// is a loud panic rather than a silently zeroed table.
+static G2_TAB: OnceLock<[FP16; ecp::G2_TABLE]> = OnceLock::new();
 
 fn ceil(a: usize,b: usize) -> usize {
     (a-1)/b+1
@@ -85,9 +89,9 @@ pub fn init() -> isize {
     if g.is_infinity() {
         return BLS_FAIL;
     }
-    unsafe {
-        pair8::precomp(&mut G2_TAB, &g);
-    }
+    let mut tab = [FP16::new(); ecp::G2_TABLE];
+    pair8::precomp(&mut tab, &g);
+    let _ = G2_TAB.set(tab);
     BLS_OK
 }
 
@@ -152,9 +156,11 @@ pub fn core_verify(sig: &[u8], m: &[u8], w: &[u8]) -> isize {
     // Use new multi-pairing mechanism
     let mut r = pair8::initmp();
     //    pair8::another(&mut r,&g,&d);
-    unsafe {
-        pair8::another_pc(&mut r, &G2_TAB, &d);
-    }
+    pair8::another_pc(
+        &mut r,
+        G2_TAB.get().expect("bls256::init() must run before verification"),
+        &d,
+    );
     pair8::another(&mut r, &pk, &hm);
     let mut v = pair8::miller(&mut r);
 
@@ -194,9 +200,11 @@ pub fn core_msig_verify(sig: &[u8], ms: &Vec<Vec<u8>>, ws: &Vec<Vec<u8>>) -> isi
     // Use new multi-pairing mechanism
     let mut r = pair8::initmp();
     //    pair8::another(&mut r,&g,&d);
-    unsafe {
-        pair8::another_pc(&mut r, &G2_TAB, &d);
-    }
+    pair8::another_pc(
+        &mut r,
+        G2_TAB.get().expect("bls256::init() must run before verification"),
+        &d,
+    );
     for (pk, hm) in pks.iter().zip(hms) {
       pair8::another(&mut r, &pk, &hm);
     }

--- a/crates/channel/src/protocols/doubleratchet.rs
+++ b/crates/channel/src/protocols/doubleratchet.rs
@@ -377,7 +377,10 @@ impl DoubleRatchetParticipant {
         let dh_output = new_receiving_ephemeral_key * self.sending_ephemeral_private_key;
         let hkdf = Hkdf::<Sha512>::new(Some(&self.root_key), &dh_output.compress().to_bytes());
         let mut rkck = [0u8; 96];
-        hkdf.expand(b"quilibrium-double-ratchet", &mut rkck);
+        // Only fails when the output length exceeds 255*HashLen (16320 for
+        // SHA-512); 96 is a compile-time constant well under that.
+        hkdf.expand(b"quilibrium-double-ratchet", &mut rkck)
+            .map_err(|e| format!("HKDF expand failed: {}", e))?;
     
         self.root_key = rkck[..32].to_vec();
         self.receiving_chain_key = rkck[32..64].to_vec();
@@ -390,7 +393,10 @@ impl DoubleRatchetParticipant {
         let dh_output = new_receiving_ephemeral_key * self.sending_ephemeral_private_key;
         let hkdf = Hkdf::<Sha512>::new(Some(&self.root_key), &dh_output.compress().to_bytes());
         let mut rkck2 = [0u8; 96];
-        hkdf.expand(b"quilibrium-double-ratchet", &mut rkck2);
+        // Only fails when the output length exceeds 255*HashLen (16320 for
+        // SHA-512); 96 is a compile-time constant well under that.
+        hkdf.expand(b"quilibrium-double-ratchet", &mut rkck2)
+            .map_err(|e| format!("HKDF expand failed: {}", e))?;
     
         self.root_key = rkck2[..32].to_vec();
         self.sending_chain_key = rkck2[32..64].to_vec();

--- a/crates/quil-execution/src/token_intrinsic/lattice_ct.rs
+++ b/crates/quil-execution/src/token_intrinsic/lattice_ct.rs
@@ -1377,11 +1377,10 @@ pub fn encode_pending_claim(e: &PendingClaimEnvelope) -> Vec<u8> {
     out
 }
 pub fn decode_pending_claim(b: &[u8]) -> Result<PendingClaimEnvelope> {
-    let mut p = 0usize;
     let mut escrow_address = [0u8; 32];
     let s = b.get(0..32).ok_or_else(|| QuilError::InvalidArgument("lattice-ct: claim eof".into()))?;
     escrow_address.copy_from_slice(s);
-    p = 32;
+    let mut p = 32usize;
     let is_to = *b.get(p).ok_or_else(|| QuilError::InvalidArgument("lattice-ct: claim eof".into()))? != 0;
     p += 1;
     let falcon_sig = take_one(b, &mut p)?;

--- a/crates/quil-hypergraph/src/addressing.rs
+++ b/crates/quil-hypergraph/src/addressing.rs
@@ -315,6 +315,7 @@ mod tests {
         };
         let b = a.clone();
         a.app_address[0] = 0xFF;
+        assert_eq!(a.app_address[0], 0xFF);
         assert_eq!(b.app_address[0], 0);
     }
 

--- a/crates/quil-store/src/clock.rs
+++ b/crates/quil-store/src/clock.rs
@@ -1113,7 +1113,7 @@ impl store::ClockStore for RocksClockStore {
         // Go's GetShardClockFrame already accepts a non-pointer value
         // at the canonical key (the `else` branch at clock.go:1290).
         let staged_key = encoding::clock_shard_staged_key(selector, frame_number);
-        let mut have_frame = false;
+        let have_frame;
         if let Some(staged_bytes) = self
             .db
             .get(&staged_key)


### PR DESCRIPTION
**10 warnings, fixed rather than silenced.** This is the only PR in the series
besides #597 that changes runtime behaviour, so it is worth a closer read than
the rest.

**`static_mut_refs` (5).** `bls::singleton`'s `SINGLETON` and `bls256`'s `G2_TAB`
both used `static mut` + `Once` + `assume_init`, which needs `unsafe` at every
access and has no synchronisation on the read side. Both become `OnceLock`.
`get_or_init` returns `&'static T`, so `singleton()` keeps its exact signature
and loses its `unsafe` block entirely. `bls256::init()` is called from exactly
one place — inside `singleton()`'s initialiser — so the ordering is unchanged; a
missing `init()` now panics loudly instead of silently pairing against an
all-zero table. (`static_mut_refs` becomes a hard error in edition 2024, so this
has to happen eventually either way.)

**`unused_must_use` (2).** `doubleratchet::ratchet_ephemeral_keys` discarded both
`hkdf.expand` results. They cannot fail here — 96 bytes is well under SHA-512's
16320-byte limit — but if they ever did, the ratchet would have continued with a
zeroed key buffer. The function already returns `Result`, so they are propagated
with the bound spelled out in a comment.

**`unused_assignments` (3).** Including `clock.rs`'s `have_frame`, which is now
an uninitialised binding so the compiler enforces that every path sets it. That
flag guards the latest-index pointer against an attacker-chosen `frame_number`,
so a future path that forgets to set it should not silently inherit `false`.

The full test suite passes on this — see the verification below — which is the
main evidence that the `OnceLock` ordering is right.

---

### Series

Part of the warning-cleanup series that starts with **#597**. The eight PRs are
disjoint and each stands on its own, but they are meant to be read in order —
**please take #597 first**: it is the only one of the eight that fixes a bug
rather than a warning, and it is the shortest.

- **Base:** `932045a3`
- **Verified with all eight applied:** the workspace goes from **309 warnings to 16** —
  the 16 being `classgroup`'s GMP FFI glue, deliberately left visible rather than
  silenced. **Update:** those 16 are now fixed rather than documented, in #605,
  which corrects the declarations and the uninitialized values instead of
  annotating them. With #605 and the channelwasm commit in #599, the combined
  tree checks with **zero** warnings.
- To check this PR on its own:
  ```
  cargo check --keep-going --workspace --lib --bins --tests --examples
  ```

