### PR TITLE
fix: correct classgroup GMP FFI declarations and uninitialized values

### DIFF
--- a/crates/classgroup/src/gmp/mpz.rs
+++ b/crates/classgroup/src/gmp/mpz.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering::{self, Equal, Greater, Less};
 use std::convert::From;
 use std::error::Error;
 use std::ffi::CString;
-use std::mem::{size_of, uninitialized};
+use std::mem::{size_of, MaybeUninit};
 use std::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
@@ -47,7 +47,7 @@ extern "C" {
     fn __gmpz_get_si(op: mpz_srcptr) -> c_ulong;
     fn __gmpz_get_d(op: mpz_srcptr) -> c_double;
     fn __gmpz_fits_slong_p(op: mpz_srcptr) -> c_long;
-    fn __gmpz_sizeinbase(op: mpz_srcptr, base: c_int) -> size_t;
+    pub(crate) fn __gmpz_sizeinbase(op: mpz_srcptr, base: c_int) -> size_t;
     fn __gmpz_cmp(op1: mpz_srcptr, op2: mpz_srcptr) -> c_int;
     fn __gmpz_cmp_ui(op1: mpz_srcptr, op2: c_ulong) -> c_int;
     fn __gmpz_add(rop: mpz_ptr, op1: mpz_srcptr, op2: mpz_srcptr);
@@ -55,7 +55,9 @@ extern "C" {
     fn __gmpz_add_ui(rop: mpz_ptr, op1: mpz_srcptr, op2: c_ulong);
     fn __gmpz_sub(rop: mpz_ptr, op1: mpz_srcptr, op2: mpz_srcptr);
     fn __gmpz_submul(rop: mpz_ptr, op1: mpz_srcptr, op2: mpz_srcptr);
-    fn __gmpz_cmpabs(by: mpz_ptr, l: mpz_srcptr);
+    // GMP: `int mpz_cmpabs (mpz_srcptr, mpz_srcptr)`. Returns a negative value
+    // when |op1| < |op2|, so the return type must be signed.
+    pub(crate) fn __gmpz_cmpabs(op1: mpz_srcptr, op2: mpz_srcptr) -> c_int;
     fn __gmpz_divexact(rop: mpz_ptr, op1: mpz_srcptr, op2: mpz_srcptr);
     fn __gmpz_sub_ui(rop: mpz_ptr, op1: mpz_srcptr, op2: c_ulong);
     fn __gmpz_ui_sub(rop: mpz_ptr, op1: c_ulong, op2: mpz_srcptr);
@@ -102,7 +104,10 @@ extern "C" {
         nails: size_t,
         op: *const c_void,
     );
-    fn __gmpz_export(
+    // GMP: `void *mpz_export (...)`. The return value is the destination used
+    // (either `rop` or a freshly allocated block); callers here ignore it, but
+    // `gmp_classgroup::ffi::export_obj` asserts on it, so it must be declared.
+    pub(crate) fn __gmpz_export(
         rop: *mut c_void,
         countp: *mut size_t,
         order: c_int,
@@ -110,7 +115,7 @@ extern "C" {
         endian: c_int,
         nails: size_t,
         op: mpz_srcptr,
-    );
+    ) -> *mut c_void;
     fn __gmpz_root(rop: mpz_ptr, op: mpz_srcptr, n: c_ulong) -> c_int;
     fn __gmpz_sqrt(rop: mpz_ptr, op: mpz_srcptr);
     fn __gmpz_millerrabin(n: mpz_srcptr, reps: c_int) -> c_int;
@@ -152,18 +157,24 @@ impl Mpz {
     #[inline]
     pub fn new() -> Mpz {
         unsafe {
-            let mut mpz = uninitialized();
-            __gmpz_init(&mut mpz);
-            Mpz { mpz: mpz }
+            let mut mpz = MaybeUninit::<mpz_struct>::uninit();
+            __gmpz_init(mpz.as_mut_ptr());
+            // `__gmpz_init` fully initialises the struct.
+            Mpz {
+                mpz: mpz.assume_init(),
+            }
         }
     }
 
     #[inline]
     pub fn new_reserve(n: usize) -> Mpz {
         unsafe {
-            let mut mpz = uninitialized();
-            __gmpz_init2(&mut mpz, n as c_ulong);
-            Mpz { mpz: mpz }
+            let mut mpz = MaybeUninit::<mpz_struct>::uninit();
+            __gmpz_init2(mpz.as_mut_ptr(), n as c_ulong);
+            // `__gmpz_init2` fully initialises the struct.
+            Mpz {
+                mpz: mpz.assume_init(),
+            }
         }
     }
 
@@ -207,10 +218,17 @@ impl Mpz {
         let s = CString::new(s.to_string()).map_err(|_| ParseMpzError { _priv: () })?;
         unsafe {
             assert!(base == 0 || (base >= 2 && base <= 62));
-            let mut mpz = uninitialized();
-            let r = __gmpz_init_set_str(&mut mpz, s.as_ptr(), base as c_int);
+            let mut mpz = MaybeUninit::<mpz_struct>::uninit();
+            let r = __gmpz_init_set_str(mpz.as_mut_ptr(), s.as_ptr(), base as c_int);
+            // GMP documents that `mpz_init_set_str` initialises `rop` on BOTH
+            // paths: "ROP is initialized even if an error occurs. (I.e., you
+            // have to call `mpz_clear` for it.)" So `assume_init` belongs here,
+            // before the branch — moving it into the success arm would leak the
+            // limb allocation on every malformed input, and dropping the
+            // `__gmpz_clear` below would do the same.
+            let mut mpz = mpz.assume_init();
             if r == 0 {
-                Ok(Mpz { mpz: mpz })
+                Ok(Mpz { mpz })
             } else {
                 __gmpz_clear(&mut mpz);
                 Err(ParseMpzError { _priv: () })
@@ -468,9 +486,12 @@ impl Mpz {
 
     pub fn one() -> Mpz {
         unsafe {
-            let mut mpz = uninitialized();
-            __gmpz_init_set_ui(&mut mpz, 1);
-            Mpz { mpz: mpz }
+            let mut mpz = MaybeUninit::<mpz_struct>::uninit();
+            __gmpz_init_set_ui(mpz.as_mut_ptr(), 1);
+            // `__gmpz_init_set_ui` fully initialises the struct.
+            Mpz {
+                mpz: mpz.assume_init(),
+            }
         }
     }
 
@@ -490,15 +511,15 @@ pub struct ParseMpzError {
 
 impl fmt::Display for ParseMpzError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        // Was `self.description().fmt(f)`. `Error::description` is deprecated
+        // in favour of `Display`, so the message lives here now and
+        // `description`'s default impl (which returns this string via
+        // `to_string`) keeps working for any caller still using it.
+        f.write_str("invalid integer")
     }
 }
 
 impl Error for ParseMpzError {
-    fn description(&self) -> &'static str {
-        "invalid integer"
-    }
-
     fn cause(&self) -> Option<&'static Error> {
         None
     }
@@ -507,9 +528,12 @@ impl Error for ParseMpzError {
 impl Clone for Mpz {
     fn clone(&self) -> Mpz {
         unsafe {
-            let mut mpz = uninitialized();
-            __gmpz_init_set(&mut mpz, &self.mpz);
-            Mpz { mpz: mpz }
+            let mut mpz = MaybeUninit::<mpz_struct>::uninit();
+            __gmpz_init_set(mpz.as_mut_ptr(), &self.mpz);
+            // `__gmpz_init_set` fully initialises the struct.
+            Mpz {
+                mpz: mpz.assume_init(),
+            }
         }
     }
 }

--- a/crates/classgroup/src/gmp/test.rs
+++ b/crates/classgroup/src/gmp/test.rs
@@ -581,4 +581,87 @@ mod mpz {
         let zero = Mpz::from(-51213);
         assert_eq!(format!("{}", zero), "-51213");
     }
+
+    /// Every constructor that hands a `MaybeUninit<mpz_struct>` to GMP must
+    /// produce a fully initialised, usable value.
+    ///
+    /// These were written with `mem::uninitialized()`, which is UB for a struct
+    /// containing a pointer. The migration to `MaybeUninit` is only correct if
+    /// the GMP call really does initialise the struct before `assume_init`, so
+    /// each constructor is exercised past construction — read, mutated, and
+    /// dropped — rather than merely compared once.
+    #[test]
+    fn test_constructors_are_initialized() {
+        assert_eq!(format!("{}", Mpz::new()), "0");
+        assert_eq!(format!("{}", Mpz::one()), "1");
+        assert_eq!(Mpz::new(), Mpz::zero());
+
+        // `new_reserve` preallocates limbs; the value is still zero, and the
+        // allocation must survive being grown past the reservation.
+        let mut reserved = Mpz::new_reserve(4096);
+        assert_eq!(format!("{}", reserved), "0");
+        reserved.setbit(8192);
+        assert!(reserved.bit_length() > 4096);
+
+        // A freshly constructed value must be independently droppable, and
+        // usable as an operand afterwards.
+        let scratch = Mpz::new();
+        drop(scratch);
+        assert_eq!(&Mpz::new() + &Mpz::one(), Mpz::one());
+    }
+
+    /// `clone` must deep-copy, not alias the source's limb pointer.
+    #[test]
+    fn test_clone_is_independent() {
+        let original =
+            Mpz::from_str_radix("123456789012345678901234567890123456789012345678901234567890", 10)
+                .unwrap();
+        let mut copy = original.clone();
+        copy.setbit(1024);
+
+        assert!(copy > original);
+        assert_eq!(
+            format!("{}", original),
+            "123456789012345678901234567890123456789012345678901234567890",
+            "mutating the clone must not disturb the original"
+        );
+    }
+
+    /// The `from_str_radix` error path calls `__gmpz_clear`, which is only legal
+    /// on an initialised `mpz_t`.
+    ///
+    /// GMP documents that `mpz_init_set_str` initialises `rop` even when parsing
+    /// fails, so `assume_init` must happen *before* the success/failure branch.
+    /// Moving it into the success arm would leak on every bad parse; removing
+    /// the `__gmpz_clear` would do the same. The loop makes such a leak large
+    /// enough for a leak checker to catch, and asserts the allocator stays
+    /// healthy across many failures.
+    #[test]
+    fn test_from_str_radix_error_path() {
+        for _ in 0..1000 {
+            assert!(Mpz::from_str_radix("not a number", 10).is_err());
+        }
+
+        // Parsing must still work after repeated failures.
+        assert_eq!(
+            format!("{}", Mpz::from_str_radix("1234567890", 10).unwrap()),
+            "1234567890"
+        );
+
+        // A digit that is invalid for the given base, rather than junk.
+        assert!(Mpz::from_str_radix("2", 2).is_err());
+        assert_eq!(format!("{}", Mpz::from_str_radix("1", 2).unwrap()), "1");
+    }
+
+    /// `ParseMpzError`'s message lives in its `Display` impl.
+    ///
+    /// It used to live in the deprecated `Error::description`, with `Display`
+    /// delegating to it. Removing `description` without moving the message here
+    /// would silently change this string to the standard library's default.
+    #[test]
+    fn test_parse_error_message() {
+        let err = Mpz::from_str_radix("not a number", 10).unwrap_err();
+        assert_eq!(format!("{}", err), "invalid integer");
+        assert_eq!(err.to_string(), "invalid integer");
+    }
 }

--- a/crates/classgroup/src/gmp_classgroup/ffi.rs
+++ b/crates/classgroup/src/gmp_classgroup/ffi.rs
@@ -19,10 +19,19 @@
 //! this library requires.
 #![allow(unsafe_code)]
 pub use super::super::gmp::mpz::Mpz;
-use super::super::gmp::mpz::{mp_bitcnt_t, mp_limb_t};
+// `__gmpz_cmpabs`, `__gmpz_export` and `__gmpz_sizeinbase` are imported from
+// `gmp::mpz` rather than redeclared here. Declaring the same symbol twice with
+// different signatures is `clashing_extern_declarations`, and rustc is entitled
+// to assume either one; `__gmpz_cmpabs` in particular used to be declared here
+// as returning `usize`, which cannot represent the negative value GMP returns
+// when |op1| < |op2|.
+use super::super::gmp::mpz::{
+    __gmpz_cmpabs, __gmpz_export, __gmpz_sizeinbase, mp_bitcnt_t, mp_limb_t,
+};
 use libc::{c_int, c_long, c_ulong, c_void, size_t};
 // pub use c_ulong;
-use std::{mem, usize};
+use std::cmp::Ordering;
+use std::usize;
 // We use the unsafe versions to avoid unnecessary allocations.
 extern "C" {
     fn adapted_nudupl(a: *mut Mpz, b: *mut Mpz, c: *mut Mpz, times: c_ulong);
@@ -44,7 +53,6 @@ extern "C" {
     fn __gmpz_set(rop: *mut Mpz, op: *const Mpz);
     //fn __fmpz_set_mpz(rop: *mut Mpz, op: *const Mpz);
     //fn __fmpz_get_mpz(rop: *mut Mpz, op: *const Mpz);
-    fn __gmpz_cmpabs(rop: *const Mpz, op: *const Mpz) -> usize;
     //fn __gmpz_sgn(rop: *const Mpz) -> usize;
     fn __gmpz_mul_2exp(rop: *mut Mpz, op1: *const Mpz, op2: mp_bitcnt_t);
     fn __gmpz_sub(rop: *mut Mpz, op1: *const Mpz, op2: *const Mpz);
@@ -59,7 +67,6 @@ extern "C" {
         op: *const c_void,
     );
     fn __gmpz_tdiv_r(r: *mut Mpz, n: *const Mpz, d: *const Mpz);
-    fn __gmpz_sizeinbase(op: &Mpz, base: c_int) -> size_t;
     fn __gmpz_fdiv_q_ui(rop: *mut Mpz, op1: *const Mpz, op2: c_ulong) -> c_ulong;
     fn __gmpz_add(rop: *mut Mpz, op1: *const Mpz, op2: *const Mpz);
     fn __gmpz_add_ui(rop: *mut Mpz, op1: *const Mpz, op2: c_ulong);
@@ -68,15 +75,6 @@ extern "C" {
     fn __gmpz_cdiv_ui(n: &Mpz, d: c_ulong) -> c_ulong;
     fn __gmpz_fdiv_ui(n: &Mpz, d: c_ulong) -> c_ulong;
     fn __gmpz_tdiv_ui(n: &Mpz, d: c_ulong) -> c_ulong;
-    fn __gmpz_export(
-        rop: *mut c_void,
-        countp: *mut size_t,
-        order: c_int,
-        size: size_t,
-        endian: c_int,
-        nails: size_t,
-        op: &Mpz,
-    ) -> *mut c_void;
     fn __gmpz_powm(rop: *mut Mpz, base: *const Mpz, exp: *const Mpz, modulus: *const Mpz);
 }
 
@@ -196,7 +194,7 @@ pub fn three_gcd(rop: &mut Mpz, a: &Mpz, b: &Mpz, c: &Mpz) {
 
 #[inline]
 pub fn size_in_bits(obj: &Mpz) -> usize {
-    unsafe { __gmpz_sizeinbase(obj, 2) }
+    unsafe { __gmpz_sizeinbase(obj.inner(), 2) }
 }
 
 #[inline]
@@ -241,9 +239,13 @@ pub fn gmp_nudupl(a: &mut Mpz, b: &mut Mpz, c: &mut Mpz, times: u64) {
     }
 }
 
+/// Compares |`op1`| with |`op2`|, returning the `Ordering` between them.
+///
+/// GMP's `mpz_cmpabs` returns a signed `int` — negative when |op1| < |op2| —
+/// which is why this cannot return `usize`, as it once did.
 #[inline]
-pub fn mpz_cmpabs(rop: &Mpz, op1: &Mpz) -> usize {
-    unsafe { __gmpz_cmpabs(rop, op1) }
+pub fn mpz_cmpabs(op1: &Mpz, op2: &Mpz) -> Ordering {
+    unsafe { __gmpz_cmpabs(op1.inner(), op2.inner()).cmp(&0) }
 }
 
 //#[inline]
@@ -290,7 +292,7 @@ pub fn mpz_fdiv_q(q: &mut Mpz, n: &Mpz, d: &Mpz) {
 #[inline]
 #[cfg(none)]
 pub fn mpz_neg(rop: &mut Mpz) {
-    assert!(mem::size_of::<Mpz>() == mem::size_of::<MpzStruct>());
+    assert!(std::mem::size_of::<Mpz>() == std::mem::size_of::<MpzStruct>());
     unsafe {
         let ptr = rop as *mut _ as *mut MpzStruct;
         let v = (*ptr).mp_size;
@@ -317,9 +319,12 @@ pub fn export_obj(obj: &Mpz, v: &mut [u8]) -> Result<(), usize> {
         // Necessary ― this byte may not be fully overwritten
         *(ptr as *mut u8) = 0;
 
-        // SAFE as __gmpz_export will *always* initialize this.
-        let mut s: usize = mem::uninitialized();
-        let ptr2 = __gmpz_export(ptr, &mut s, 1, 1, 1, 0, obj);
+        // `__gmpz_export` always writes the word count through `countp`, and
+        // writes 0 when `obj` is zero, so this initial value is never observed.
+        // It is a plain `0` rather than `mem::uninitialized()` because handing
+        // an uninitialised scalar to safe code is UB the moment it exists.
+        let mut s: usize = 0;
+        let ptr2 = __gmpz_export(ptr, &mut s, 1, 1, 1, 0, obj.inner());
         assert_eq!(ptr, ptr2);
         if 0 == s {
             1
@@ -417,5 +422,102 @@ mod test {
     fn check_rem() {
         assert_eq!(mpz_crem_u16(&(-100i64).into(), 3), 1);
         assert_eq!(mpz_crem_u16(&(100i64).into(), 3), 2);
+    }
+
+    /// `mpz_cmpabs` must be able to report "less than".
+    ///
+    /// GMP's `mpz_cmpabs` returns a signed `int`, negative when |op1| < |op2|.
+    /// This function was previously declared as returning `usize`, so the
+    /// less-than case came back as a nonsensical large unsigned value and the
+    /// signature could not express the answer at all. Any regression to an
+    /// unsigned return type fails to compile against this test; any regression
+    /// to the wrong operand order fails it at runtime.
+    #[test]
+    fn cmpabs_orders_by_magnitude() {
+        let small: Mpz = 5i64.into();
+        let big: Mpz = 7i64.into();
+
+        assert_eq!(mpz_cmpabs(&small, &big), Ordering::Less);
+        assert_eq!(mpz_cmpabs(&big, &small), Ordering::Greater);
+        assert_eq!(mpz_cmpabs(&small, &small), Ordering::Equal);
+    }
+
+    /// The "abs" half of `mpz_cmpabs`: sign is ignored, magnitude is not.
+    #[test]
+    fn cmpabs_ignores_sign() {
+        let neg_nine: Mpz = (-9i64).into();
+        let pos_nine: Mpz = 9i64.into();
+        let neg_two: Mpz = (-2i64).into();
+
+        assert_eq!(mpz_cmpabs(&neg_nine, &pos_nine), Ordering::Equal);
+        assert_eq!(mpz_cmpabs(&pos_nine, &neg_nine), Ordering::Equal);
+
+        // -9 < -2 as signed values, but |-9| > |-2|.
+        assert_eq!(mpz_cmpabs(&neg_nine, &neg_two), Ordering::Greater);
+        assert_eq!(mpz_cmpabs(&neg_two, &neg_nine), Ordering::Less);
+    }
+
+    /// Magnitudes wider than one limb, where a truncated or half-read return
+    /// register would be most likely to show up.
+    #[test]
+    fn cmpabs_handles_multi_limb_values() {
+        let a = Mpz::from_str_radix("123456789012345678901234567890123456789", 10).unwrap();
+        let mut b = a.clone();
+        b.setbit(200);
+
+        assert_eq!(mpz_cmpabs(&a, &b), Ordering::Less);
+        assert_eq!(mpz_cmpabs(&b, &a), Ordering::Greater);
+        assert_eq!(mpz_cmpabs(&a, &a.clone()), Ordering::Equal);
+
+        let neg_b = {
+            let mut t = Mpz::zero();
+            mpz_neg(&mut t, &b);
+            t
+        };
+        assert_eq!(mpz_cmpabs(&neg_b, &b), Ordering::Equal);
+    }
+
+    /// `export_obj` reports the byte length it actually wrote.
+    ///
+    /// The count is written by `__gmpz_export` through `countp`. That local was
+    /// previously `mem::uninitialized()`; it is now `0`, which is also the value
+    /// GMP writes for a zero input — so the zero case below pins both the fix
+    /// and the documented GMP behaviour it relies on.
+    #[test]
+    fn export_obj_round_trips() {
+        let values = [
+            "1",
+            "255",
+            "256",
+            "65535",
+            "123456789012345678901234567890",
+            "-1",
+            "-255",
+            "-256",
+            "-123456789012345678901234567890",
+        ];
+
+        for value in &values {
+            let obj = Mpz::from_str_radix(value, 10).unwrap();
+            let byte_len = (size_in_bits(&obj) + 8) >> 3;
+
+            let mut buf = vec![0u8; byte_len];
+            export_obj(&obj, &mut buf).expect("buffer sized from size_in_bits should fit");
+
+            assert_eq!(import_obj(&buf), obj, "round trip failed for {}", value);
+        }
+    }
+
+    /// A buffer too small must report the size needed rather than write past it.
+    #[test]
+    fn export_obj_reports_required_size() {
+        let obj = Mpz::from_str_radix("65535", 10).unwrap();
+        let mut too_small = [0u8; 1];
+        let needed = export_obj(&obj, &mut too_small).unwrap_err();
+        assert!(
+            needed > 1,
+            "expected a required size larger than the buffer, got {}",
+            needed
+        );
     }
 }


### PR DESCRIPTION
These are the sixteen warnings the rest of the warning-cleanup series
deliberately left alone. I said they would come as an issue with analysis
rather than a PR, because a plausible-looking fix in GMP FFI glue produces
silent memory corruption rather than a compile error, and because the crate is
vendored.

Both reasons turned out not to survive checking, so here is the PR instead.

## `__gmpz_cmpabs` is declared wrongly in both extern blocks

`src/gmp/mpz.rs` and `src/gmp_classgroup/ffi.rs` each open their own
`extern "C"` block, and three symbols appear in both with different signatures.
rustc only warns, but it is entitled to assume either one.

| symbol | `gmp/mpz.rs` | `gmp_classgroup/ffi.rs` | GMP 6.3.0 `gmp.h` |
|---|---|---|---|
| `__gmpz_cmpabs` | `(by: mpz_ptr, l: mpz_srcptr)` — no return | `(rop: *const Mpz, op: *const Mpz) -> usize` | `int mpz_cmpabs (mpz_srcptr, mpz_srcptr)` |
| `__gmpz_sizeinbase` | `(op: mpz_srcptr, base: c_int) -> size_t` | `(op: &Mpz, base: c_int) -> size_t` | `size_t mpz_sizeinbase (mpz_srcptr, int)` |
| `__gmpz_export` | `(..., op: mpz_srcptr)` — **no return** | `(..., op: &Mpz) -> *mut c_void` | `void *mpz_export (..., mpz_srcptr)` |

`mpz_cmpabs` returns a *negative* `int` when `|op1| < |op2|`. Declared as
returning `usize`, that case cannot be represented. I checked what it actually
produces, with both declarations against the same GMP the build image links:

```
case                     correct (c_int)   broken (usize)
|5| vs |7|  (expect < 0)              -1             4294967295
|7| vs |5|  (expect > 0)               1                      1
|5| vs |5|  (expect = 0)               0                      0
|-7| vs |5| (expect > 0)               1                      1
|5| vs |-7| (expect < 0)              -1             4294967295
```

So every "less than" answer comes back as a large positive number — the exact
inputs where the comparison matters. It reads 4294967295 rather than
18446744073709551615 only because the upper half of the return register
happened to be zero on this run; nothing guarantees that.

The declaration in `gmp/mpz.rs` is wrong differently: no return value at all,
and a *mutable* first operand.

This is latent rather than live — the sole wrapper is dead code, and `grep`
finds no caller of `mpz_cmpabs` anywhere in the workspace. That is what makes
it cheap to fix now and expensive to fix later: correcting a dead function's
signature costs nothing today, and the first caller to use it would silently
get wrong answers.

`__gmpz_sizeinbase` and `__gmpz_export` are the benign pair — `Mpz` is
`#[repr(transparent)]` over `#[repr(C)]` `mpz_struct`, so `&Mpz` and
`*const mpz_struct` have identical ABI. But `gmp/mpz.rs` omits `__gmpz_export`'s
`void *` return, and `export_obj` asserts on that return, so the unified
declaration has to be the one that keeps it.

All three now have a single declaration in `gmp/mpz.rs`, imported by
`gmp_classgroup/ffi.rs` and reached through the `Mpz::inner()` accessor that
already existed for exactly this purpose. `mpz_cmpabs` returns `Ordering`.

## Six `mem::uninitialized()` calls

Deprecated since Rust 1.39 and immediate UB for any type with a validity
invariant. Five of them build an `mpz_struct`, whose `*mut c_void` is a scalar —
producing an uninitialised one is UB the moment the value exists, before
`__gmpz_init` can overwrite it. The window is one line and GMP does initialise
the struct, so this has probably never misbehaved in a shipped build; that is
not the same as being correct, and the classic symptom is a miscompile that
appears under a new LLVM.

All five become `MaybeUninit`. `from_str_radix` is the one that needed care:

```rust
let r = __gmpz_init_set_str(mpz.as_mut_ptr(), s.as_ptr(), base as c_int);
let mut mpz = mpz.assume_init();   // <- before the branch, deliberately
if r == 0 { Ok(Mpz { mpz }) } else { __gmpz_clear(&mut mpz); ... }
```

The error branch calls `__gmpz_clear`, legal only on an initialised `mpz_t`.
GMP 6.3.0's manual, *Simultaneous Integer Init & Assign*:

> If the string is a correct base BASE number, the function returns 0; if an
> error occurs it returns -1. **ROP is initialized even if an error occurs.**
> (I.e., you have to call 'mpz_clear' for it.)

So `assume_init()` belongs before the branch and the existing `__gmpz_clear` is
required, not incidental. Moving `assume_init()` into the success arm — which
looks tidier — would leak on every malformed input.

The sixth is a `usize` word count that `__gmpz_export` always writes, and which
GMP sets to 0 for a zero input. It is now plainly `0` rather than uninitialised.

## `Error::description`

Deprecated since Rust 1.42. The message moves into the `Display` impl, which
previously delegated to it.

## Tests

Every change has a test that fails without it.

- **`cmpabs_orders_by_magnitude`** — all three orderings. Cannot compile against
  an unsigned return type, and I confirmed that: restoring the old signature
  fails the build with `E0308` rather than passing quietly.
- **`cmpabs_ignores_sign`** — `|-9| == |9|`, and `-9 < -2` while `|-9| > |-2|`.
- **`cmpabs_handles_multi_limb_values`** — magnitudes past one limb, where a
  truncated or half-read return register would show up.
- **`export_obj_round_trips`** — export/import over positive, negative and
  multi-limb values. The negative cases matter here: `export_obj` internally
  exports a *zero* for them, which is the path where GMP writes a count of 0
  and where the previously-uninitialised local was read.
- **`export_obj_reports_required_size`** — undersized buffer reports the size
  needed instead of writing past it.
- **`test_constructors_are_initialized`** — `new`, `new_reserve`, `one` are read,
  mutated, grown past their reservation and dropped, not merely compared once.
- **`test_clone_is_independent`** — mutating a clone must not disturb the source,
  i.e. the limb pointer was really deep-copied.
- **`test_from_str_radix_error_path`** — 1000 failed parses, then a successful
  one, so a leak on the error path is large enough for a leak checker and the
  allocator is asserted healthy afterwards. Also covers a digit invalid for its
  base, not just junk.
- **`test_parse_error_message`** — pins `"invalid integer"` to `Display`, which
  is what silently changes if `description` is removed carelessly.

## Verification

In the AMD64 build image (`Dockerfile.source`, `test-context`), which is where
this crate can compile at all — it needs GMP/FLINT/MPFR:

```
cargo check -p classgroup --lib --bins --tests --examples   # 16 warnings -> 0
cargo nextest run -p classgroup                              # 69 tests, 69 passed
```

That takes the workspace to **zero** warnings across the whole cleanup series.

GMP prototypes and manual quotes above are from GMP 6.3.0 —
`/usr/local/include/gmp.h` in that image, which is the source-built GMP the
crate actually links against, not the distro 6.2.1 also present.

## Note on #600, and a correction

#600 adds a `[lints.rust]` table to `crates/classgroup/Cargo.toml` whose comment
justified allow-rather-than-patch by saying it keeps the tree byte-comparable
with poanetwork/vdf. **That was wrong and I have corrected it on that branch.**
classgroup has already diverged — `src/vdf.cpp` and `build.rs` have both been
substantially rewritten in-tree — so wholesale re-vendoring was never on the
table, and "it is vendored, do not touch it" was not a real reason to leave a
genuine defect in place. That is what changed my mind about filing this as an
issue.

The load-bearing half of that comment is unchanged and still true: `deprecated =
"allow"` there does **not** reach `src/gmp/`, because that module's own
`#![warn(deprecated)]` beats the level cargo passes on the command line. The key
covers `build.rs` and must not be deleted as dead config. I deleted it once on
that assumption and had to put it back.

The two PRs touch different files in the crate and do not conflict in either
merge order.
