### PR TITLE
fix: backfill below the first head on an empty store

### DIFF
--- a/crates/quil-rpc/src/frame_sync.rs
+++ b/crates/quil-rpc/src/frame_sync.rs
@@ -372,6 +372,29 @@ impl Default for ArchivePollerConfig {
     }
 }
 
+/// The single fetch surface [`run_archive_poller`] needs from its remote
+/// source: `GetGlobalFrame(n)`, with `0` meaning "latest head". Extracted
+/// from [`ArchiveClient`] so tests can inject an in-process fake source and
+/// drive the poller loop deterministically (see the `forward_fill_repro`
+/// tests); production goes through the impl below over the real mTLS client.
+#[tonic::async_trait]
+pub trait PollerFrameSource: Send {
+    async fn get_global_frame(
+        &mut self,
+        frame_number: u64,
+    ) -> Result<GlobalFrame, ArchiveClientError>;
+}
+
+#[tonic::async_trait]
+impl PollerFrameSource for ArchiveClient {
+    async fn get_global_frame(
+        &mut self,
+        frame_number: u64,
+    ) -> Result<GlobalFrame, ArchiveClientError> {
+        ArchiveClient::get_global_frame(self, frame_number).await
+    }
+}
+
 /// Long-running task that polls a chosen archive endpoint for the current
 /// head, and forward-fills any gap from the previously seen head. The
 /// returned future runs until `cancel` fires; callers register it with
@@ -380,9 +403,31 @@ pub async fn run_archive_poller(
     pool: Arc<ArchiveEndpointPool>,
     clock_store: Arc<RocksClockStore>,
     falcon_signing_key: Vec<u8>,
-    mut config: ArchivePollerConfig,
+    config: ArchivePollerConfig,
     cancel: CancellationToken,
 ) {
+    run_archive_poller_with_connector(pool, clock_store, config, cancel, move |addr: String| {
+        let key = falcon_signing_key.clone();
+        async move { ArchiveClient::connect_mtls(&addr, &key).await }
+    })
+    .await
+}
+
+/// Generic core of [`run_archive_poller`]: identical loop, with the remote
+/// source injectable via `connect` (production passes a closure over
+/// `ArchiveClient::connect_mtls`; tests pass an in-process fake). Kept
+/// crate-private — the mTLS wrapper above is the public entry point.
+pub(crate) async fn run_archive_poller_with_connector<S, F, C>(
+    pool: Arc<ArchiveEndpointPool>,
+    clock_store: Arc<RocksClockStore>,
+    mut config: ArchivePollerConfig,
+    cancel: CancellationToken,
+    connect: C,
+) where
+    S: PollerFrameSource,
+    C: Fn(String) -> F,
+    F: std::future::Future<Output = Result<S, ArchiveClientError>>,
+{
     info!("archive frame poller started");
     pool.wait_nonempty(&cancel).await;
     if cancel.is_cancelled() {
@@ -402,7 +447,7 @@ pub async fn run_archive_poller(
     // Reuse a single client for as long as it works AND it keeps us moving
     // forward. Switch endpoints on an RPC failure OR when an endpoint stops
     // being ahead of us (see the no-progress handling below).
-    let mut current_client: Option<(String, ArchiveClient)> = None;
+    let mut current_client: Option<(String, S)> = None;
     // Use the local store's latest as our starting "last seen", so a
     // restart doesn't re-fetch frames we already have.
     let mut last_frame: u64 = clock_store.get_latest_frame_number().unwrap_or(0);
@@ -575,7 +620,7 @@ pub async fn run_archive_poller(
         // Acquire a working client.
         if current_client.is_none() {
             if let Some(addr) = pool.next().await {
-                match ArchiveClient::connect_mtls(&addr, &falcon_signing_key).await {
+                match connect(addr.clone()).await {
                     Ok(c) => {
                         info!(%addr, "archive poller connected");
                         current_client = Some((addr, c));
@@ -1169,5 +1214,254 @@ mod pool_tests {
         assert!(!gf.fresh_within(Duration::from_millis(0)));
         // A generous window is.
         assert!(gf.fresh_within(Duration::from_secs(60)));
+    }
+}
+
+/// In-process repro for the poller's empty-store forward-fill hole.
+///
+/// Observed live in the devnet partition harness: an archive isolated while
+/// frames 1..k finalize comes back, polls a head N, and permanently serves
+/// NotFound for the missed frames — its serial materializer wedges below the
+/// registrations it needs. Mechanism: the forward-fill guard
+/// (`config.forward_fill && last_frame > 0 && …`) treats an empty store
+/// (`last_frame == 0`, every fresh boot) as "nothing to fill", so the first
+/// successful head poll stores ONLY the head and latches `last_frame` past
+/// the hole. No runtime path revisits frames below the cursor (the
+/// record-gap scan runs at bootstrap only), so the hole is permanent.
+///
+/// NOT archive-specific: `forward_fill: true` is set for EVERY node role
+/// (see `master_node/archive_sync.rs` — regulars need contiguity too, their
+/// app-shard storage attestations anchor ρ_N to an exact global frame that
+/// must be present locally). Regular nodes merely shrink the window: gossip
+/// stores frames independently and a far-behind boot state-jumps, but a
+/// client whose store is empty at its first head poll while gossip missed
+/// the early frames (boot-time partition, mesh forming late, gossip drops)
+/// hits the identical skip — and its materializer/ρ_N anchors wedge the
+/// same way.
+///
+/// The two RED tests are the repro — they FAIL on this branch and are meant
+/// to be attached to a bug report:
+/// - `empty_store_first_head_poll_must_backfill_full_history` (archive
+///   mode: `gossip_freshness: None`)
+/// - `client_mode_empty_store_hits_the_same_skip` (regular-node mode:
+///   `gossip_freshness: Some`, mesh quiet — the client boot race)
+/// `seeded_store_gap_is_forward_filled` is the passing contrast: the same
+/// gap above a NON-empty cursor is filled, showing the inconsistency.
+#[cfg(test)]
+mod forward_fill_repro {
+    use super::*;
+    use std::collections::BTreeMap;
+    use quil_types::proto::global::{GlobalFrame, GlobalFrameHeader};
+
+    /// Minimal frame that satisfies `RocksClockStore::put_global_frame`
+    /// (header present; requests empty).
+    fn mk_frame(n: u64) -> GlobalFrame {
+        GlobalFrame {
+            header: Some(GlobalFrameHeader {
+                frame_number: n,
+                output: vec![n as u8; 32],
+                ..Default::default()
+            }),
+            requests: vec![],
+        }
+    }
+
+    /// In-process archive: serves `0` as "latest" and exact frame numbers
+    /// otherwise, with a real gRPC `NotFound` status for absent frames so the
+    /// poller's NotFound-detection paths behave as in production.
+    #[derive(Clone)]
+    struct FakeArchive {
+        frames: Arc<std::sync::Mutex<BTreeMap<u64, GlobalFrame>>>,
+    }
+
+    impl FakeArchive {
+        fn serving(range: std::ops::RangeInclusive<u64>) -> Self {
+            let frames = range.map(|n| (n, mk_frame(n))).collect();
+            Self { frames: Arc::new(std::sync::Mutex::new(frames)) }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl PollerFrameSource for FakeArchive {
+        async fn get_global_frame(
+            &mut self,
+            frame_number: u64,
+        ) -> Result<GlobalFrame, ArchiveClientError> {
+            let frames = self.frames.lock().unwrap();
+            let found = if frame_number == 0 {
+                frames.values().next_back().cloned()
+            } else {
+                frames.get(&frame_number).cloned()
+            };
+            found.ok_or_else(|| {
+                ArchiveClientError::Rpc(tonic::Status::not_found(format!(
+                    "frame {frame_number} not found"
+                )))
+            })
+        }
+    }
+
+    struct Rig {
+        _tmp: tempfile::TempDir,
+        store: Arc<RocksClockStore>,
+        seen: Arc<std::sync::Mutex<Vec<u64>>>,
+        cancel: CancellationToken,
+        poller: tokio::task::JoinHandle<()>,
+    }
+
+    /// Spawn the real poller loop (forward_fill on — every node role runs
+    /// with it, see the module comment) against `fake`, over a fresh Rocks
+    /// store optionally pre-seeded with frames. `gossip` selects the role:
+    /// `None` = archive mode (always RPC-polls); `Some` = regular-node mode
+    /// (the poller consults the freshness signal first — an unstamped signal
+    /// models a client whose gossip mesh has delivered nothing, so it falls
+    /// through to the same RPC head-poll + forward-fill path).
+    async fn spawn_poller(
+        fake: FakeArchive,
+        seed_frames: &[u64],
+        gossip: Option<Arc<GossipFreshness>>,
+    ) -> Rig {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = quil_store::RocksDb::open(tmp.path()).unwrap();
+        let store = Arc::new(RocksClockStore::new(db.inner()));
+        for n in seed_frames {
+            store.put_global_frame(&mk_frame(*n), None).unwrap();
+        }
+
+        let pool = Arc::new(ArchiveEndpointPool::new(Duration::from_secs(60)));
+        pool.add("fake-archive:8340".into()).await;
+
+        let seen: Arc<std::sync::Mutex<Vec<u64>>> = Arc::new(std::sync::Mutex::new(vec![]));
+        let seen_cb = seen.clone();
+        let config = ArchivePollerConfig {
+            poll_interval: Duration::from_millis(20),
+            call_timeout: Duration::from_secs(1),
+            forward_fill: true,
+            gossip_freshness: gossip,
+            on_frame: Some(Arc::new(move |f: &GlobalFrame| {
+                if let Some(h) = f.header.as_ref() {
+                    seen_cb.lock().unwrap().push(h.frame_number);
+                }
+            })),
+            ..Default::default()
+        };
+
+        let cancel = CancellationToken::new();
+        let poller = tokio::spawn(run_archive_poller_with_connector(
+            pool,
+            store.clone(),
+            config,
+            cancel.clone(),
+            move |_addr: String| {
+                let f = fake.clone();
+                async move { Ok::<_, ArchiveClientError>(f) }
+            },
+        ));
+        Rig { _tmp: tmp, store, seen, cancel, poller }
+    }
+
+    /// Wait (bounded) until the store's latest-frame cursor reaches `head`,
+    /// then stop the poller. Returns whether the head was reached at all.
+    async fn await_head_then_stop(rig: &Rig, head: u64) -> bool {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut reached = false;
+        while tokio::time::Instant::now() < deadline {
+            if rig.store.get_latest_frame_number() == Some(head) {
+                reached = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        rig.cancel.cancel();
+        reached
+    }
+
+    /// REPRO (fails on this branch): a poller booted on an EMPTY store must
+    /// backfill the full history below the first head it sees — an archive
+    /// needs frames 1..head, and the materializer requires contiguity.
+    /// Instead, the `last_frame > 0` arm of the forward-fill guard skips the
+    /// fill, only the head frame is stored, and the hole below it is
+    /// permanent (nothing revisits frames under the cursor at runtime).
+    #[tokio::test]
+    async fn empty_store_first_head_poll_must_backfill_full_history() {
+        let rig = spawn_poller(FakeArchive::serving(1..=5), &[], None).await;
+        assert!(
+            await_head_then_stop(&rig, 5).await,
+            "poller never even reached the head — setup problem, not the repro"
+        );
+        rig.poller.abort();
+
+        let missing: Vec<u64> = (1..=5)
+            .filter(|n| rig.store.get_global_frame(*n).is_err())
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "frames {missing:?} were permanently skipped: the forward-fill guard \
+             (`config.forward_fill && last_frame > 0 && …`) treats an empty store \
+             (last_frame == 0) as nothing-to-fill, so the first successful head poll \
+             stores only the head and latches the cursor past the hole; no runtime \
+             path revisits frames below the cursor (the record-gap scan is \
+             bootstrap-only), so a serial materializer wedges here forever. \
+             on_frame saw {:?}, want [1, 2, 3, 4, 5]",
+            rig.seen.lock().unwrap(),
+        );
+    }
+
+    /// REPRO (fails on this branch), regular-node flavor: `forward_fill` is
+    /// on for regulars too (their ρ_N storage-attestation anchors need exact
+    /// global frames locally), and a client can reach its first head poll
+    /// with an empty store while gossip missed the early frames — a
+    /// boot-time partition or a late-forming mesh (devnet run 1's archive-4
+    /// race, on a client). The unstamped freshness signal models the quiet
+    /// mesh; the poller falls through to the identical RPC path and the
+    /// identical guard skips the identical fill.
+    #[tokio::test]
+    async fn client_mode_empty_store_hits_the_same_skip() {
+        let rig = spawn_poller(FakeArchive::serving(1..=5), &[], Some(GossipFreshness::new()))
+            .await;
+        assert!(
+            await_head_then_stop(&rig, 5).await,
+            "poller never even reached the head — setup problem, not the repro"
+        );
+        rig.poller.abort();
+
+        let missing: Vec<u64> = (1..=5)
+            .filter(|n| rig.store.get_global_frame(*n).is_err())
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "frames {missing:?} were permanently skipped in REGULAR-NODE mode: the \
+             empty-store forward-fill guard is role-independent, so a client that \
+             boots into a quiet gossip mesh latches onto the first polled head and \
+             never backfills — its serial materializer and ρ_N anchor lookups then \
+             wedge exactly like an archive's. on_frame saw {:?}, want [1, 2, 3, 4, 5]",
+            rig.seen.lock().unwrap(),
+        );
+    }
+
+    /// Contrast (passes): the SAME gap above a non-empty cursor IS forward-
+    /// filled — store holds frame 1, head jumps to 5, frames 2..4 get
+    /// fetched, stored, and fired in order. Shows the empty-store case is an
+    /// inconsistency in the guard, not a designed limitation of the loop.
+    #[tokio::test]
+    async fn seeded_store_gap_is_forward_filled() {
+        let rig = spawn_poller(FakeArchive::serving(1..=5), &[1], None).await;
+        assert!(
+            await_head_then_stop(&rig, 5).await,
+            "poller did not fill the gap and reach head 5"
+        );
+        rig.poller.abort();
+
+        for n in 1..=5u64 {
+            assert!(
+                rig.store.get_global_frame(n).is_ok(),
+                "frame {n} missing after forward-fill from a seeded cursor"
+            );
+        }
+        assert_eq!(
+            *rig.seen.lock().unwrap(),
+            vec![2, 3, 4, 5],
+            "forward-fill must fire on_frame for each filled frame, then the head"
+        );
     }
 }

--- a/crates/quil-rpc/src/frame_sync.rs
+++ b/crates/quil-rpc/src/frame_sync.rs
@@ -502,6 +502,11 @@ pub(crate) async fn run_archive_poller_with_connector<S, F, C>(
     // it — a recently-produced frame that's briefly unavailable is served by
     // its producer within a few frames, so a large lag means "permanent".
     const UNFILLABLE_HEAD_MARGIN: u64 = 16;
+    // Most frames a single tick will forward-fill before yielding back to the
+    // loop (and its cancellation check). Well above the achievable rate — each
+    // frame is a serial round-trip — so this bounds worst-case tick duration
+    // without throttling catch-up.
+    const MAX_FORWARD_FILL_PER_TICK: u64 = 512;
 
     let mut ticker = tokio::time::interval(config.poll_interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -754,7 +759,32 @@ pub(crate) async fn run_archive_poller_with_connector<S, F, C>(
         // 2. Forward-fill any missed frames in (last_frame, new_number).
         //    Archive nodes need the full history; everyone else
         //    just wants to start from the current head.
-        if config.forward_fill && last_frame > 0 && new_number > last_frame + 1 {
+        //
+        // An EMPTY store (`last_frame == 0`) is a gap like any other, and used
+        // to be excluded here by a `last_frame > 0` arm. That treated every
+        // fresh boot as "nothing to fill": the first successful head poll
+        // stored ONLY the head and latched the cursor past everything below it,
+        // and nothing revisits frames under the cursor at runtime (the
+        // record-gap scan runs at bootstrap only), so the hole was permanent.
+        // It is not archive-specific — `forward_fill` is set for every node
+        // role, because regulars need contiguity too (their app-shard storage
+        // attestations anchor ρ_N to an exact global frame that must be present
+        // locally). Regulars merely have a smaller window to hit it in: the
+        // runtime far-behind rescue above tries a state-jump first, and only a
+        // node whose jump does not complete crawls up from genesis here.
+        if config.forward_fill && new_number > last_frame + 1 {
+            // Bound the span filled per tick. Dropping the guard above means a
+            // fresh archive at mainnet height would otherwise attempt a single
+            // genesis-to-head crawl inside ONE tick — an unbounded loop with no
+            // cancellation check in it. Filling a bounded chunk and resuming on
+            // the next tick keeps the loop responsive to `cancel` and bounds the
+            // work per iteration, at no throughput cost: each frame is a
+            // round-trip, so the real fill rate is far below this ceiling.
+            let fill_end = new_number.min(
+                last_frame
+                    .saturating_add(1)
+                    .saturating_add(MAX_FORWARD_FILL_PER_TICK),
+            );
             // Track partial progress: every frame we successfully store
             // advances `last_frame`, so a failure midway does NOT throw
             // away the frames we already pulled. The previous design left
@@ -773,7 +803,7 @@ pub(crate) async fn run_archive_poller_with_connector<S, F, C>(
             // opposed to NotFound / transport). Counts toward the same skip via
             // its own distinct-endpoint tally.
             let mut failed_validation = false;
-            for fn_ in (last_frame + 1)..new_number {
+            for fn_ in (last_frame + 1)..fill_end {
                 // Store-first (non-archive): if gossip already delivered this
                 // frame, use the local copy and skip the RPC. Only frames gossip
                 // missed cost a network fetch. Fire on_frame just as the RPC arm
@@ -908,6 +938,18 @@ pub(crate) async fn run_archive_poller_with_connector<S, F, C>(
                     _ = cancel.cancelled() => break,
                     _ = tokio::time::sleep(Duration::from_secs(5)) => {}
                 }
+                continue;
+            }
+            if fill_end < new_number {
+                // Chunk done but the gap is still open. Do NOT fall through to
+                // head processing: storing the head here would latch the cursor
+                // past the frames we have not fetched yet — the very skip this
+                // fill exists to prevent. Resume from `last_frame` next tick.
+                debug!(
+                    local_frame = last_frame,
+                    head = new_number,
+                    "catchup: filled a bounded chunk — resuming below head next tick"
+                );
                 continue;
             }
         }
@@ -1321,6 +1363,17 @@ mod forward_fill_repro {
         seed_frames: &[u64],
         gossip: Option<Arc<GossipFreshness>>,
     ) -> Rig {
+        spawn_poller_with_jump(fake, seed_frames, gossip, None).await
+    }
+
+    /// As `spawn_poller`, but able to wire the runtime far-behind rescue hook —
+    /// the branch that decides whether a regular node state-jumps or crawls.
+    async fn spawn_poller_with_jump(
+        fake: FakeArchive,
+        seed_frames: &[u64],
+        gossip: Option<Arc<GossipFreshness>>,
+        far_behind_jump: Option<FarBehindJump>,
+    ) -> Rig {
         let tmp = tempfile::TempDir::new().unwrap();
         let db = quil_store::RocksDb::open(tmp.path()).unwrap();
         let store = Arc::new(RocksClockStore::new(db.inner()));
@@ -1338,6 +1391,7 @@ mod forward_fill_repro {
             call_timeout: Duration::from_secs(1),
             forward_fill: true,
             gossip_freshness: gossip,
+            far_behind_jump,
             on_frame: Some(Arc::new(move |f: &GlobalFrame| {
                 if let Some(h) = f.header.as_ref() {
                     seen_cb.lock().unwrap().push(h.frame_number);
@@ -1462,6 +1516,106 @@ mod forward_fill_repro {
             *rig.seen.lock().unwrap(),
             vec![2, 3, 4, 5],
             "forward-fill must fire on_frame for each filled frame, then the head"
+        );
+    }
+
+    /// Coverage for the bounded fill that replaced the `last_frame > 0` guard:
+    /// a gap wider than `MAX_FORWARD_FILL_PER_TICK` (512) must still close
+    /// contiguously, just across several ticks.
+    ///
+    /// The interesting case is the tick boundary. A chunk that ends below the
+    /// head must NOT fall through to head processing — storing the head there
+    /// would latch the cursor past the unfetched remainder and reintroduce
+    /// exactly the permanent hole this fix removes. So the head is stored only
+    /// on the tick that closes the gap, and the result is dense from 1 to head.
+    #[tokio::test]
+    async fn gap_wider_than_one_chunk_fills_contiguously_across_ticks() {
+        const HEAD: u64 = 600; // > MAX_FORWARD_FILL_PER_TICK
+        let rig = spawn_poller(FakeArchive::serving(1..=HEAD), &[], None).await;
+        assert!(
+            await_head_then_stop(&rig, HEAD).await,
+            "poller did not reach head {HEAD} across multiple fill chunks"
+        );
+        rig.poller.abort();
+
+        let missing: Vec<u64> = (1..=HEAD)
+            .filter(|n| rig.store.get_global_frame(*n).is_err())
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "frames {missing:?} missing — a bounded chunk must resume below the head, \
+             never latch the cursor past the frames it has not fetched yet",
+        );
+        assert_eq!(
+            *rig.seen.lock().unwrap(),
+            (1..=HEAD).collect::<Vec<u64>>(),
+            "on_frame must fire once per frame, in order, across the chunk boundary",
+        );
+    }
+
+    /// The regular-node escape hatch, and the reason removing the
+    /// `last_frame > 0` guard is acceptable for non-archives.
+    ///
+    /// Filling from an empty store means the head is stored only once the gap
+    /// closes, so a node far from head would climb to it one frame at a time.
+    /// Regulars must not: the runtime far-behind rescue fires FIRST (empty store
+    /// ⇒ the gap is the whole chain, so it clears `STATE_JUMP_RUNTIME_GAP`),
+    /// state-jumps near head, and the poller resumes from there. Only a regular
+    /// whose jump does not complete crawls up from genesis.
+    ///
+    /// Archives are deliberately excluded from this path (`far_behind_jump` is
+    /// `None` for them in `archive_sync.rs`) — they need the full history, so
+    /// crawling is the correct behaviour there.
+    #[tokio::test]
+    async fn regular_node_far_behind_state_jumps_instead_of_crawling_from_genesis() {
+        const HEAD: u64 = STATE_JUMP_RUNTIME_GAP + 500; // far enough to trigger
+        const JUMP_TO: u64 = HEAD - 100;
+
+        let jumped: Arc<std::sync::Mutex<Vec<u64>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let jump_log = jumped.clone();
+        let jump: FarBehindJump = Arc::new(move |head: u64, _cancel: CancellationToken| {
+            jump_log.lock().unwrap().push(head);
+            Box::pin(async move { Some(JUMP_TO) })
+        });
+
+        let rig = spawn_poller_with_jump(
+            FakeArchive::serving(1..=HEAD),
+            &[],
+            Some(GossipFreshness::new()),
+            Some(jump),
+        )
+        .await;
+        assert!(
+            await_head_then_stop(&rig, HEAD).await,
+            "poller never reached head {HEAD} after the state-jump"
+        );
+        rig.poller.abort();
+
+        assert!(
+            !jumped.lock().unwrap().is_empty(),
+            "the far-behind rescue never fired — an empty store is the whole chain \
+             behind, so a regular node must state-jump rather than crawl",
+        );
+        // The jump landed at JUMP_TO, so the poller fills only above it. Nothing
+        // below may have been fetched: that crawl is exactly what the rescue exists
+        // to avoid.
+        let crawled: Vec<u64> = (1..=JUMP_TO)
+            .filter(|n| rig.store.get_global_frame(*n).is_ok())
+            .collect();
+        assert!(
+            crawled.is_empty(),
+            "frames {crawled:?} were fetched below the state-jump target — the \
+             poller crawled from genesis instead of resuming at the jump",
+        );
+        // Above the jump it still forward-fills contiguously to the head.
+        let missing: Vec<u64> = (JUMP_TO + 1..=HEAD)
+            .filter(|n| rig.store.get_global_frame(*n).is_err())
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "frames {missing:?} missing above the jump target — the post-jump gap \
+             must still be forward-filled",
         );
     }
 }


### PR DESCRIPTION
An attempt to fix the bug @dazthecorgi found and reproduced in #587. His repro commit is included unchanged, so his two red tests are the proof here; this adds the fix he handed off.

**Base:** `932045a3`

**The bug.** The forward-fill guard read `config.forward_fill && last_frame > 0 && new_number > last_frame + 1`, so an empty store — every fresh boot — was "nothing to fill". The first head poll stored only the head and latched the cursor past everything below it, and nothing revisits frames under the cursor at runtime (the record-gap scan is bootstrap-only), so the hole was permanent and a serial materializer wedged beneath it. Not archive-specific: `forward_fill` is on for every role, because regulars need contiguity too for their ρ_N storage anchors.

**The fix.** An empty store is a gap like any other, so the `last_frame > 0` arm is gone. Dropping it alone would let a fresh archive at mainnet height attempt a genesis-to-head crawl inside one tick — an unbounded loop with no cancellation check — so the fill is bounded to 512 frames per tick. A truncated chunk deliberately does *not* fall through to head processing: storing the head there would latch the cursor past the unfetched remainder and reintroduce the same hole. It resumes below the head next tick.

The bound costs no throughput (each frame is a serial round-trip, so the real rate is far below the ceiling) and it makes the loop responsive to `cancel` during a long catch-up, which it was not before.

**Behaviour change worth flagging:** a regular node with an empty store whose state-jump does not complete now crawls up from genesis instead of skipping to head. That is the contiguity ρ_N requires, and the runtime far-behind rescue still tries the jump first — but it is a real change for that path.

**Tests.** Daz's two repros fail before this change (`on_frame` sees only `[5]`) and pass after; his seeded-cursor contrast still passes. Two more added:

- `gap_wider_than_one_chunk_fills_contiguously_across_ticks` — pins the new chunk boundary.
- `regular_node_far_behind_state_jumps_instead_of_crawling_from_genesis` — pins the claim above rather than leaving it in prose: the rescue fires, nothing below the jump target is fetched, and the post-jump gap is still filled. It needed `spawn_poller` to delegate to a `spawn_poller_with_jump`; Daz's call sites are untouched.

Full `-p quil-rpc`: 130/130.

