### PR TITLE
chore: log the archive address on forest-sync warnings

### DIFF
--- a/crates/quil-node/src/forest_sync.rs
+++ b/crates/quil-node/src/forest_sync.rs
@@ -227,6 +227,7 @@ pub async fn sync_single_shard_verified(
         let Some((v_s, root_s)) = head else { continue };
         if phase == 0 && !expected_va_root.is_empty() && root_s.as_slice() != expected_va_root {
             warn!(
+                addr = %addr,
                 peer = %hex::encode(&root_s),
                 expected = %hex::encode(expected_va_root),
                 "peer vertex-adds root != expected — not syncing",
@@ -270,7 +271,7 @@ pub async fn pull_shard_from_peer(
                 if phase == 0 {
                     return Err(e);
                 }
-                warn!(phase, error = %e, "forest sync: non-anchor phase failed (best-effort)");
+                warn!(addr = %addr, phase, error = %e, "forest sync: non-anchor phase failed (best-effort)");
             }
         }
     }


### PR DESCRIPTION
## Log the archive address on forest-sync warnings

### Problem

When a node's prover-tree sync rejects an archive's vertex-adds root, the
warning identifies *what* diverged but not *who* served it:

```
warn  quil_node/src/forest_sync.rs:229  peer vertex-adds root != expected — not syncing
{"coreId":0,
 "expected":"8061c599eede0f4732281fa655979c0463d5ed5c72fcea0e862d7bb26a8b2db2",
 "peer":"a9a5777b80ce0ac735e83c2a2eb2cafbe19bcf2179cff9f7becacca92206fcca"}
```

The `peer` field is `hex::encode(&root_s)` — the *root the archive served*, not a
peer identity. So an operator seeing this repeat every 5 minutes can tell that
some archive is serving a divergent root, but cannot tell which one, and has to
guess by correlating against unrelated `frame_sync` poller lines.

`sync_single_shard_verified` receives `addr: &str` as its first argument, so the
information is already in scope at the warn site. Same for the best-effort warn
in `pull_shard_from_peer`.

### Change

Add `addr` to both `warn!` sites in `forest_sync.rs`. Two lines, no behaviour
change, no new arguments.

### Why it matters

During the current archive resync, operators can see *that* an archive is
serving a bad root but cannot report *which*, which is exactly the information
needed to narrow it down. This turns an unactionable warning into an actionable
one.

### Testing

Logging-only change; no logic touched.

Compiled clean on top of `v2.1.0.25` (932045a3) via
`docker/Dockerfile.sourceavx512`, `--target=node`, release profile:
zero errors, 232 MB binary produced, and both warn format strings verified
present in the resulting binary.
