### PR TITLE
fix(test): restore ProverPipeline loopback fields in test initializers

### DIFF
--- a/crates/quil-engine/tests/common/mod.rs
+++ b/crates/quil-engine/tests/common/mod.rs
@@ -1292,6 +1292,8 @@ pub fn build_tier2_archive_rig_with_key_manager(
         transport: transport.clone() as Arc<dyn ProverMessageTransport>,
         hypergraph: None,
         replica_store: None,
+        local_message_collector: None,
+        current_frame: None,
     });
 
     let _ = all_provers; // unused in this builder — kept for API symmetry
@@ -1388,6 +1390,8 @@ pub fn build_test_pipeline_with_registry(
         transport: transport as Arc<dyn ProverMessageTransport>,
         hypergraph: None,
         replica_store: None,
+        local_message_collector: None,
+        current_frame: None,
     });
     TestPipelineRig {
         pipeline,

--- a/crates/quil-engine/tests/e2e_consensus.rs
+++ b/crates/quil-engine/tests/e2e_consensus.rs
@@ -584,6 +584,8 @@ async fn tier2_non_archive_join_lands_in_archive_registry() {
             as Arc<dyn quil_engine::prover_message_transport::ProverMessageTransport>,
         hypergraph: None,
         replica_store: None,
+        local_message_collector: None,
+        current_frame: None,
     });
 
     // 5. Pick a filter that exists in shards_store. Genesis seeds


### PR DESCRIPTION
`932045a3` removed `local_message_collector: None` and `current_frame: None` from all three test-side `ProverPipeline` initializers, but both fields are still declared on the struct (`crates/quil-engine/src/prover_pipeline.rs:83,87`). `quil-engine`'s test targets therefore do not compile:

```
error[E0063]: missing fields `current_frame` and `local_message_collector`
              in initializer of `ProverPipeline`
  crates/quil-engine/tests/common/mod.rs:1283, :1379
  crates/quil-engine/tests/e2e_consensus.rs:918
error: could not compile `quil-engine` (test "e2e_epoch_confirm")
error: could not compile `quil-engine` (test "e2e_consensus")
```

`None` is what both fields' own doc comments prescribe for tests, so this restores prior behaviour exactly — 6 lines, no semantic change.

`cargo check --workspace` does not build test targets, so `build` stays green and only `test (cargo nextest)` is affected — on every PR targeting `v2.1.0.25`.
