### PR TITLE
fix(test): seed shard allocations for the storage-attestation e2e

### DIFF
--- a/crates/quil-engine/tests/e2e_consensus.rs
+++ b/crates/quil-engine/tests/e2e_consensus.rs
@@ -182,7 +182,39 @@ async fn worker_active_storage_attestation() {
         .try_init();
 
     let provers: Vec<TestProver> = (0..4).map(|_| TestProver::generate()).collect();
-    let infos: Vec<_> = provers.iter().map(|p| p.to_prover_info(1)).collect();
+    // Every member needs an Active allocation on THIS shard's filter, confirmed
+    // for the epoch the frame anchors to. `prove_next_state`'s effective-Active
+    // gate (app_engine.rs) refuses to propose a storage frame unless the local
+    // prover holds one — a prover admitted to the committee without it would mint
+    // an attestation whose leaf roots are for a future epoch. `to_prover_info`
+    // leaves `allocations` empty, which is fine for the legacy path
+    // (`anchor_gfn == 0` skips the gate) but not here: `StorageHarness::seeded`
+    // anchors at global frame 1000.
+    let infos: Vec<_> = provers
+        .iter()
+        .map(|p| {
+            let mut info = p.to_prover_info(1);
+            info.allocations = vec![quil_types::consensus::ProverAllocationInfo {
+                status: quil_types::consensus::ProverStatus::Active,
+                confirmation_filter: vec![0x55; 32],
+                rejection_filter: Vec::new(),
+                join_frame_number: 0,
+                leave_frame_number: 0,
+                pause_frame_number: 0,
+                resume_frame_number: 0,
+                kick_frame_number: 0,
+                join_confirm_frame_number: 0,
+                join_reject_frame_number: 0,
+                leave_confirm_frame_number: 0,
+                leave_reject_frame_number: 0,
+                last_active_frame_number: 1000,
+                epoch: quil_types::consensus::epoch_for_frame(1000),
+                ring: 0,
+                vertex_address: Vec::new(),
+            }];
+            info
+        })
+        .collect();
     let registry = Arc::new(TestProverRegistry::with_provers(infos));
 
     // `seeded` lowers `storage_activation_frame()` to 1000 and builds the


### PR DESCRIPTION
**Base:** `2b96656e`

`worker_active_storage_attestation` times out after 90s — the shard never produces a frame.

`TestProver::to_prover_info` builds a `ProverInfo` with an empty `allocations` vector. `prove_next_state`'s effective-Active proposing gate asks

```rust
info.allocations.iter().any(|a| a.confirmation_filter == self.filter
    && a.effective_status(anchor_gfn) == EffectiveStatus::Active)
```

which is vacuously false on an empty vector, so every view nullifies with `NoVote`.

The gate is behind `if anchor_gfn > 0`. Every other CW test leaves the global anchor at genesis and skips it; this is the only one that seeds a global frame (`StorageHarness::seeded(1000)`), which is what makes it live. The committee checks upstream of it still pass because `TestProverRegistry::get_active_provers` ignores the filter and the allocations entirely — so the fixture admits provers to a committee they hold no allocation on, a shape production cannot build.

The test and `to_prover_info` both date from `961297ec`; the gate arrived later in `324ffb3b`. It stayed invisible because the E0063 break (#613) stopped the target compiling at all, and CI does not run on this branch (#616).

Fix: seed each member an Active allocation on the shard filter, confirmed for the anchor's epoch.

On `epoch`: its doc calls `0` a "genesis/grandfather sentinel", but `effective_status` has no `epoch == 0` case. Genesis appears not to need one — genesis provers are seeded with the empty filter, which returns Active before the epoch comparison is reached — so the comment reads as stale rather than as describing missing code. Not touched here.

`cargo nextest run -p quil-engine --test e2e_consensus` → 14/14 pass; `worker_active_storage_attestation` 1.229s, previously a 90s timeout.

Out of scope: the gate itself, and the CW/PoRep attestation follow-up noted in the test's own comment.
