### PR TITLE
fix(test): make the shard-split authorization gate live in the fixture

### DIFF
--- a/crates/quil-engine/tests/materialize_harness.rs
+++ b/crates/quil-engine/tests/materialize_harness.rs
@@ -454,7 +454,7 @@ fn split_fixture() -> (
         hg_store.clone() as Arc<dyn quil_types::store::HypergraphStore>,
         Arc::new(NoopInclusionProver),
     ));
-    let state = quil_execution::hypergraph_state::HypergraphState::new(crdt);
+    let state = quil_execution::hypergraph_state::HypergraphState::new(crdt.clone());
     let registry = Arc::new(quil_execution::prover_registry::SharedProverRegistry::new());
 
     let gi = quil_execution::global_intrinsic::intrinsic::GlobalIntrinsic::new_with_stores(
@@ -467,6 +467,15 @@ fn split_fixture() -> (
     .with_frame_header_deps(
         registry.clone() as Arc<dyn ProverRegistry>,
         Arc::new(quil_engine::rewards::OptRewardIssuance),
+    )
+    // The active-global-prover gate reads COMMITTED state, and skips itself
+    // entirely when the hypergraph slot is empty (followers trust the finalized
+    // frame's QC instead). Without this the authorization check below is vacuous
+    // and a non-global proposer is accepted.
+    .with_kick_verify_deps(
+        Arc::new(quil_crypto::FalconKeyConstructor),
+        crdt.clone(),
+        Arc::new(NoopInclusionProver),
     );
 
     (gi, state, shards_store, registry, hg_store)
@@ -502,8 +511,17 @@ fn seed_global_prover(
     let mut vkp = vec![0xFFu8; 32];
     vkp.extend_from_slice(&prover_addr);
     hg_store.save_vertex_underlying_txn(txn.as_ref(), "vertex", "adds", &shard, &vkp, &prover_blob).unwrap();
+    // The gate looks the allocation up at `allocation_address(pubkey, <empty>)`,
+    // not at an arbitrary flat key: `verify_shard_op_signer_is_active_global`
+    // reads the signer's PublicKey out of the prover tree and derives the
+    // GLOBAL-filter allocation address from it. Seeding elsewhere makes a global
+    // prover unfindable; deriving it from this prover's own filter is what makes
+    // the non-global case miss (and so be rejected).
+    let alloc_addr =
+        quil_execution::global_intrinsic::materialize::allocation_address(pubkey, filter).unwrap();
+    let _ = alloc_flat_byte;
     let mut vka = vec![0xFFu8; 32];
-    vka.extend_from_slice(&[alloc_flat_byte; 32]);
+    vka.extend_from_slice(&alloc_addr);
     hg_store.save_vertex_underlying_txn(txn.as_ref(), "vertex", "adds", &shard, &vka, &alloc_blob).unwrap();
     txn.commit().unwrap();
     registry.refresh_from_store(hg_store);
@@ -623,9 +641,15 @@ fn shard_split_by_global_prover_registers_enumerable_child_and_rejects_non_globa
         let proposer = seed_global_prover(&state, &hg_store, &registry, &vec![0xEEu8; 57], 0xAA, &vec![0x33u8; 64]);
         let bytes = shard_split_bytes(&shard_address, &proposer);
         let res = gi.invoke_step(1, &bytes, &state);
+        let err = res.expect_err("a non-global proposer must be rejected (proposer_is_active_global)");
+        // Pin the REASON, not just the rejection: without this the test passes
+        // just as well when the op is refused for an unrelated reason (a bad
+        // signature, a missing prover vertex), which is how the authorization
+        // dimension went silently inert once the gate moved to committed state.
+        let msg = err.to_string();
         assert!(
-            res.is_err(),
-            "a non-global proposer must be rejected (proposer_is_active_global)"
+            msg.contains("not an active global prover"),
+            "expected the active-global-prover gate to reject, got: {msg}"
         );
         assert!(
             shards_store.range_app_shards().unwrap().is_empty(),


### PR DESCRIPTION
**Base:** `2b96656e`

`shard_split_by_global_prover_registers_enumerable_child_and_rejects_non_global` fails — a non-global proposer is accepted.

`proposer_is_active_global` authorizes against committed hypergraph state and skips itself when that slot is empty:

```rust
let Some(hg) = self.hypergraph.as_ref() else { return true };
```

`split_fixture` never installs it — `with_kick_verify_deps` is the only setter, and the fixture calls only `with_frame_header_deps` — so the gate returns `true` unconditionally.

The skip is deliberate and consistent with validate (`if let Some(hg)`), so invoke and validate still agree on the same node. What no longer holds is the fixture's node shape: the previous implementation read `prover_registry`, which the fixture does install, and failed closed when it was absent.

Both halves of the test were inert, not only the failing one. The positive half was passing for the wrong reason, and could not have passed for the right one: `seed_global_prover` stores the allocation vertex at an arbitrary flat key, while `verify_shard_op_signer_is_active_global` reads the signer's PublicKey out of the prover tree and looks up `allocation_address(pubkey, <empty filter>)`. The registry path tolerated the flat key because `refresh_from_store` keys by the tree's ProverAddress field rather than by the storage key.

Fix: install the crdt, and seed the allocation at the derived address — deriving it from the prover's own filter is what makes the non-global case miss the empty-filter lookup and be rejected. The assertion now pins the rejection reason; a bare `is_err()` passes just as well when the op is refused for an unrelated reason, which is how this dimension went silently inert.

`cargo nextest run -p quil-engine --test materialize_harness` → 9/9 pass. The four other `split_fixture` users pass with the gate now live, so it accepts the legitimate global prover rather than merely rejecting everything.

Out of scope: whether the gate should fail open when the hypergraph slot is empty. That is a product decision; this only makes the test exercise the behaviour as written.
