### PR TITLE
fix(bench): index the rpm bench with usize, cast at the API boundary

### DIFF
--- a/crates/rpm/benches/bench_rpm.rs
+++ b/crates/rpm/benches/bench_rpm.rs
@@ -2,16 +2,16 @@ use curve25519_dalek::Scalar;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
-  let smsize = 100;
+  let smsize: usize = 100;
   let msize = smsize*smsize;
-  let depth = 4;
-  let players = 9;
-  let dealers = 3;
+  let depth: usize = 4;
+  let players: usize = 9;
+  let dealers: usize = 3;
 
   //todo parties should be + 1
-  let is1 = rpm::rpm_generate_initial_shares(msize, depth, dealers, players);
-  let is2 = rpm::rpm_generate_initial_shares(msize, depth, dealers, players);
-  let is3 = rpm::rpm_generate_initial_shares(msize, depth, dealers, players);
+  let is1 = rpm::rpm_generate_initial_shares(msize as u64, depth as u64, dealers as u64, players as u64);
+  let is2 = rpm::rpm_generate_initial_shares(msize as u64, depth as u64, dealers as u64, players as u64);
+  let is3 = rpm::rpm_generate_initial_shares(msize as u64, depth as u64, dealers as u64, players as u64);
   let (m1, r1) = (is1.ms, is1.rs);
   let (m2, r2) = (is2.ms, is2.rs);
   let (m3, r3) = (is3.ms, is3.rs);
@@ -37,7 +37,7 @@ fn criterion_benchmark(c: &mut Criterion) {
           rs[i][2][j] = r3[j][i].clone();
       }
 
-      let cs = rpm::rpm_combine_shares_and_mask(ms[i].clone(), rs[i].clone(), msize, depth, dealers);
+      let cs = rpm::rpm_combine_shares_and_mask(ms[i].clone(), rs[i].clone(), msize as u64, depth as u64, dealers as u64);
       let (m, r, mrm) = (cs.ms, cs.rs, cs.mrms);
       let sp = rpm::rpm_sketch_propose(m.clone(), r.clone());
       let (mcc, rcc) = (sp.mp, sp.rp);
@@ -60,10 +60,10 @@ fn criterion_benchmark(c: &mut Criterion) {
   
   let mut group = c.benchmark_group("rpm");
   group.sample_size(10);
-  group.bench_function(format!("rpm init {}", msize), |b| b.iter(|| black_box(rpm::rpm_generate_initial_shares(msize, depth, 3, 9))));
-  group.bench_function(format!("rpm combine {}", msize), |b| b.iter(|| black_box(rpm::rpm_combine_shares_and_mask(ms[0].clone(), rs[0].clone(), msize, depth, dealers))));
+  group.bench_function(format!("rpm init {}", msize), |b| b.iter(|| black_box(rpm::rpm_generate_initial_shares(msize as u64, depth as u64, 3, 9))));
+  group.bench_function(format!("rpm combine {}", msize), |b| b.iter(|| black_box(rpm::rpm_combine_shares_and_mask(ms[0].clone(), rs[0].clone(), msize as u64, depth as u64, dealers as u64))));
   group.bench_function(format!("rpm sketch propose {}", msize), |b| b.iter(|| black_box(rpm::rpm_sketch_propose(mc[0].clone(), rc[0].clone()))));
-  group.bench_function(format!("rpm sketch verify {}", msize), |b| b.iter(|| black_box(rpm::rpm_sketch_verify(mccs.clone(), rccs.clone(), dealers))));
+  group.bench_function(format!("rpm sketch verify {}", msize), |b| b.iter(|| black_box(rpm::rpm_sketch_verify(mccs.clone(), rccs.clone(), dealers as u64))));
   group.bench_function(format!("rpm permute {}", msize), |b| b.iter(|| black_box(rpm::rpm_permute(xs.clone(), mc[0].clone(), rc[0].clone(), mrmc[0].clone(), 0, vec![1,2,3,4,5,6,7,8,9]))));
 }
 


### PR DESCRIPTION
**Base:** `2b96656e`

`test_rpm` (`crates/rpm/src/lib.rs:1212`) is the working twin of this bench — same call sequence, same six-deep share layout, `size` 100 rather than 10000 — and already resolves the `u64`/`usize` collision by binding `usize` and casting at the API boundary:

```rust
let depth = 15 as usize;
let is1 = rpm_generate_initial_shares(100, depth as u64, dealers as u64, players as u64);
```

This applies the same pattern to the bench, so the two stay consistent.

Fixing rather than dropping the target, because it runs: `cargo bench -p rpm --bench bench_rpm -- --test` gives `Success` on all 5 benchmarks at the file's own parameters (`msize` 10000).

It is expensive to run, though — that single-iteration pass took ~12 min and peaked at 6.35 GB RSS (`is1`–`is3` hold ~1.15 GB each, `ms` a further 3.5 GB), and a real `cargo bench` with `sample_size(10)` is far longer. Compile-checking the target is cheap; running it in CI would not be.

Out of scope: the `//todo parties should be + 1` at line 11, and the bench's parameters.

Fixes #614.
