### PR TITLE
fix: bootstrap app-shard workers from archived frames

### DIFF
--- a/crates/quil-engine/src/app_engine.rs
+++ b/crates/quil-engine/src/app_engine.rs
@@ -71,6 +71,14 @@ pub enum AppEngineMessage {
     /// so the gap would re-fire forever and later-arriving full frames
     /// could be re-applied on top of the already-synced tree.
     ShardSyncCompleted { synced_to_frame: u64 },
+    /// A worker with no local app-shard clock head fetched an archive anchor and
+    /// synced its tree to that anchor's pre-state. The engine validates the
+    /// certified frames, installs the predecessor as its local clock head, then
+    /// restarts simplex from that lineage.
+    ShardBootstrapCompleted {
+        anchor: quil_types::proto::global::AppShardFrame,
+        predecessor: Option<quil_types::proto::global::AppShardFrame>,
+    },
     /// (P3 / commonware-simplex) A frame this shard's simplex engine FINALIZED
     /// (prost-encoded `AppShardFrame`). Routed from `AppSeamFinalizer::on_finalized`
     /// (which runs on the simplex engine thread) into the engine run loop so it
@@ -1696,6 +1704,48 @@ impl AppConsensusEngine {
         self.try_materialize_follower_frames().await;
     }
 
+    /// Frame N advertises state after N-1, so install certified frame N-1 as
+    /// the clock head after the worker tree has synced to N's roots.
+    async fn install_archive_bootstrap(
+        &mut self,
+        anchor: quil_types::proto::global::AppShardFrame,
+        predecessor: Option<quil_types::proto::global::AppShardFrame>,
+    ) -> bool {
+        let synced_to = match archive_bootstrap_predecessor_height(
+            &self.app_address,
+            &anchor,
+            predecessor.as_ref(),
+        ) {
+            Ok(height) => height,
+            Err(error) => {
+                warn!(core_id = self.core_id, error, "app-shard bootstrap: invalid archive chain");
+                return false;
+            }
+        };
+        let anchor_n = anchor.header.as_ref().expect("checked above").frame_number;
+        let Some(validator) = self.app_frame_validator.as_ref() else {
+            warn!(core_id = self.core_id, "app-shard bootstrap: validator not ready");
+            return false;
+        };
+        if !matches!(validate_app_frame_panic_safe(validator, &anchor, false), Ok(true)) {
+            warn!(core_id = self.core_id, frame = anchor_n, "app-shard bootstrap: archive anchor failed validation");
+            return false;
+        }
+        if synced_to == 0 {
+            return true;
+        }
+        let predecessor = predecessor.expect("non-genesis chain checked above");
+        if !matches!(validate_app_frame_panic_safe(validator, &predecessor, false), Ok(true)) {
+            warn!(core_id = self.core_id, frame = synced_to, "app-shard bootstrap: predecessor failed validation");
+            return false;
+        }
+        self.commit_shard_clock_head(&predecessor, synced_to);
+        self.reconcile_with_sync(synced_to).await;
+        info!(core_id = self.core_id, anchor_frame = anchor_n, synced_to,
+            "app-shard bootstrap installed archive predecessor and synced pre-state");
+        true
+    }
+
     /// (B) At the moment this worker's anchored global frame reaches the unified
     /// cutover, fold its covered app's pre-cutover per-sub-shard trees into the
     /// single app.l2 tree (the consolidation hook) and flip its CRDT to unified —
@@ -1926,6 +1976,14 @@ impl AppConsensusEngine {
                         Some(AppEngineMessage::ShardSyncCompleted { synced_to_frame }) => {
                             self.reconcile_with_sync(synced_to_frame).await;
                         }
+                        Some(AppEngineMessage::ShardBootstrapCompleted { anchor, predecessor }) => {
+                            if !self.install_archive_bootstrap(anchor, predecessor).await {
+                                continue;
+                            }
+                            if let Some(old) = self.cw_handle.take() {
+                                old.shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
+                            }
+                        }
                         Some(AppEngineMessage::CwFinalizedFrame {
                             frame,
                             cert,
@@ -1946,6 +2004,17 @@ impl AppConsensusEngine {
                                     // (the block is still verified at `verify`, so this
                                     // is authorization/DoS hardening, not a safety hole).
                                     if quil_cw_consensus::falcon_base::FalconPublicKey::from_bytes(&from).is_some() {
+                                        if let Ok(frame) = <quil_types::proto::global::AppShardFrame as prost::Message>::decode(data.as_slice()) {
+                                            if let Some(header) = frame.header.as_ref() {
+                                                let cursor = self.shard_mat_frame.load(std::sync::atomic::Ordering::Relaxed);
+                                                if header.frame_number > cursor.saturating_add(1) {
+                                                    let _ = self.event_tx.send(AppEngineEvent::AncestorSyncRequested {
+                                                        filter: self.filter.clone(),
+                                                        missing_frames: vec![cursor.saturating_add(1)],
+                                                    });
+                                                }
+                                            }
+                                        }
                                         (h.ingest_block)(data);
                                     } else {
                                         tracing::debug!(
@@ -3565,6 +3634,39 @@ impl AppConsensusEngine {
     }
 }
 
+/// Verify the structural relation between an archive anchor N and its required
+/// predecessor N-1. Certificate validation remains in `install_archive_bootstrap`;
+/// keeping this portion pure makes the fail-closed bootstrap boundary testable.
+fn archive_bootstrap_predecessor_height(
+    app_address: &[u8],
+    anchor: &quil_types::proto::global::AppShardFrame,
+    predecessor: Option<&quil_types::proto::global::AppShardFrame>,
+) -> std::result::Result<u64, &'static str> {
+    let anchor_header = anchor.header.as_ref().ok_or("anchor has no header")?;
+    if anchor_header.frame_number == 0 {
+        return Err("anchor is genesis");
+    }
+    if anchor_header.address != app_address || anchor_header.state_roots.len() != 4 {
+        return Err("malformed or wrong-shard anchor");
+    }
+    let synced_to = anchor_header.frame_number - 1;
+    if synced_to == 0 {
+        return Ok(0);
+    }
+    let predecessor = predecessor.ok_or("archive omitted predecessor")?;
+    let previous_header = predecessor.header.as_ref().ok_or("predecessor has no header")?;
+    if previous_header.address != app_address || previous_header.frame_number != synced_to {
+        return Err("non-contiguous or wrong-shard predecessor");
+    }
+    let expected_parent = quil_crypto::poseidon::hash_bytes_to_32(&previous_header.output)
+        .map(|h| h.to_vec())
+        .map_err(|_| "invalid predecessor output")?;
+    if anchor_header.parent_selector != expected_parent {
+        return Err("anchor does not link to predecessor");
+    }
+    Ok(synced_to)
+}
+
 // =====================================================================
 // Message validation
 // =====================================================================
@@ -4057,6 +4159,67 @@ fn validate_app_frame_panic_safe(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn bootstrap_frame(
+        address: Vec<u8>,
+        frame_number: u64,
+        output: Vec<u8>,
+        parent_selector: Vec<u8>,
+    ) -> quil_types::proto::global::AppShardFrame {
+        quil_types::proto::global::AppShardFrame {
+            header: Some(quil_types::proto::global::FrameHeader {
+                address,
+                frame_number,
+                output,
+                parent_selector,
+                state_roots: vec![vec![1], vec![2], vec![3], vec![4]],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn archive_bootstrap_accepts_contiguous_anchor_and_predecessor() {
+        let address = vec![0xaa; 32];
+        let predecessor = bootstrap_frame(address.clone(), 6, vec![0x42; 32], vec![]);
+        let parent_selector = quil_crypto::poseidon::hash_bytes_to_32(&[0x42; 32])
+            .unwrap()
+            .to_vec();
+        let anchor = bootstrap_frame(address.clone(), 7, vec![0x43; 32], parent_selector);
+
+        assert_eq!(
+            archive_bootstrap_predecessor_height(&address, &anchor, Some(&predecessor)),
+            Ok(6)
+        );
+    }
+
+    #[test]
+    fn archive_bootstrap_rejects_missing_or_unlinked_predecessor() {
+        let address = vec![0xbb; 32];
+        let predecessor = bootstrap_frame(address.clone(), 6, vec![0x42; 32], vec![]);
+        let anchor = bootstrap_frame(address.clone(), 7, vec![0x43; 32], vec![0; 32]);
+
+        assert_eq!(
+            archive_bootstrap_predecessor_height(&address, &anchor, None),
+            Err("archive omitted predecessor")
+        );
+        assert_eq!(
+            archive_bootstrap_predecessor_height(&address, &anchor, Some(&predecessor)),
+            Err("anchor does not link to predecessor")
+        );
+    }
+
+    #[test]
+    fn archive_bootstrap_allows_first_frame_without_predecessor() {
+        let address = vec![0xcc; 32];
+        let anchor = bootstrap_frame(address.clone(), 1, vec![0x42; 32], vec![]);
+
+        assert_eq!(
+            archive_bootstrap_predecessor_height(&address, &anchor, None),
+            Ok(0)
+        );
+    }
 
     /// Go parity (`app_consensus_engine.go:718`): core 0 → `db.path`; worker
     /// core N → `worker_paths[N-1]` else `worker_path_prefix` (`%d`→N); empty

--- a/crates/quil-engine/src/app_engine.rs
+++ b/crates/quil-engine/src/app_engine.rs
@@ -1727,17 +1727,51 @@ impl AppConsensusEngine {
             warn!(core_id = self.core_id, "app-shard bootstrap: validator not ready");
             return false;
         };
-        if !matches!(validate_app_frame_panic_safe(validator, &anchor, false), Ok(true)) {
-            warn!(core_id = self.core_id, frame = anchor_n, "app-shard bootstrap: archive anchor failed validation");
-            return false;
+        match validate_app_frame_panic_safe(validator, &anchor, false) {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    core_id = self.core_id,
+                    frame = anchor_n,
+                    global_frame = anchor.header.as_ref().map(|h| h.global_frame_number),
+                    signature_present = anchor.header.as_ref().and_then(|h| h.public_key_signature_bls48581.as_ref()).is_some(),
+                    "app-shard bootstrap: archive anchor validation returned false"
+                );
+                return false;
+            }
+            Err(error) => {
+                let header = anchor.header.as_ref().expect("checked above");
+                let signature = header.public_key_signature_bls48581.as_ref();
+                warn!(
+                    core_id = self.core_id,
+                    frame = anchor_n,
+                    global_frame = header.global_frame_number,
+                    state_root_lengths = ?header.state_roots.iter().map(Vec::len).collect::<Vec<_>>(),
+                    signature_present = signature.is_some(),
+                    signature_len = signature.map(|s| s.signature.len()),
+                    bitmask_len = signature.map(|s| s.bitmask.len()),
+                    storage_attestation_root_len = header.storage_attestation_root.len(),
+                    error = %error,
+                    "app-shard bootstrap: archive anchor validation failed"
+                );
+                return false;
+            }
         }
         if synced_to == 0 {
             return true;
         }
         let predecessor = predecessor.expect("non-genesis chain checked above");
-        if !matches!(validate_app_frame_panic_safe(validator, &predecessor, false), Ok(true)) {
-            warn!(core_id = self.core_id, frame = synced_to, "app-shard bootstrap: predecessor failed validation");
-            return false;
+        match validate_app_frame_panic_safe(validator, &predecessor, false) {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(core_id = self.core_id, frame = synced_to, "app-shard bootstrap: predecessor validation returned false");
+                return false;
+            }
+            Err(error) => {
+                warn!(core_id = self.core_id, frame = synced_to, error = %error,
+                    "app-shard bootstrap: predecessor validation failed");
+                return false;
+            }
         }
         self.commit_shard_clock_head(&predecessor, synced_to);
         self.reconcile_with_sync(synced_to).await;

--- a/crates/quil-engine/src/prover_tree_syncer.rs
+++ b/crates/quil-engine/src/prover_tree_syncer.rs
@@ -9,6 +9,7 @@
 
 use async_trait::async_trait;
 use quil_types::error::Result;
+use quil_types::proto::global::AppShardFrame;
 
 /// Syncs the global prover tree (vertex-adds set for the global
 /// intrinsic address) from an archive. Returns `true` if the
@@ -38,5 +39,11 @@ pub trait ProverTreeSyncer: Send + Sync {
     /// sync.
     async fn sync_shard_tree(&self, _filter: &[u8], _expected_roots: &[Vec<u8>]) -> Result<bool> {
         Ok(false)
+    }
+
+    /// Fetch an app-shard frame from an archive. `frame_number == 0` requests
+    /// the latest frame and is used to seed an empty worker's clock lineage.
+    async fn get_app_shard_frame(&self, _filter: &[u8], _frame_number: u64) -> Result<Option<AppShardFrame>> {
+        Ok(None)
     }
 }

--- a/crates/quil-engine/src/thread_worker.rs
+++ b/crates/quil-engine/src/thread_worker.rs
@@ -725,25 +725,64 @@ impl ThreadWorkerManager {
                                                                         .ok()
                                                                         .and_then(|f| f.header)
                                                                         .map(|h| (h.frame_number, h.state_roots));
-                                                                    let (pinned_frame, expected_roots) = match latest {
-                                                                        Some((n, r)) => (n, r),
-                                                                        None => {
-                                                                            sync_in_progress.store(false, std::sync::atomic::Ordering::SeqCst);
-                                                                            continue;
-                                                                        }
-                                                                    };
-                                                                    let synced_to_frame = pinned_frame.saturating_sub(1);
                                                                     let lb = loopback_handle.clone();
                                                                     let flag = sync_in_progress.clone();
                                                                     let f = filter.clone();
                                                                     tokio::spawn(async move {
-                                                                        match syncer.sync_shard_tree(&f, &expected_roots).await {
-                                                                            Ok(true) => {
-                                                                                tracing::info!(filter = %hex::encode(&f), synced_to_frame, "app-shard catch-up sync converged");
-                                                                                lb.send(crate::app_engine::AppEngineMessage::ShardSyncCompleted { synced_to_frame });
+                                                                        match latest {
+                                                                            Some((pinned_frame, expected_roots)) => {
+                                                                                let synced_to_frame = pinned_frame.saturating_sub(1);
+                                                                                match syncer.sync_shard_tree(&f, &expected_roots).await {
+                                                                                    Ok(true) => {
+                                                                                        tracing::info!(filter = %hex::encode(&f), synced_to_frame, "app-shard catch-up sync converged");
+                                                                                        lb.send(crate::app_engine::AppEngineMessage::ShardSyncCompleted { synced_to_frame });
+                                                                                    }
+                                                                                    Ok(false) => tracing::warn!(filter = %hex::encode(&f), "app-shard catch-up sync did not converge"),
+                                                                                    Err(e) => tracing::warn!(filter = %hex::encode(&f), error = %e, "app-shard catch-up sync failed"),
+                                                                                }
                                                                             }
-                                                                            Ok(false) => tracing::warn!(filter = %hex::encode(&f), "app-shard catch-up sync did not converge"),
-                                                                            Err(e) => tracing::warn!(filter = %hex::encode(&f), error = %e, "app-shard catch-up sync failed"),
+                                                                            None => {
+                                                                                let anchor = match syncer.get_app_shard_frame(&f, 0).await {
+                                                                                    Ok(Some(frame)) => frame,
+                                                                                    Ok(None) => {
+                                                                                        tracing::warn!(filter = %hex::encode(&f), "app-shard bootstrap: archive has no frame");
+                                                                                        flag.store(false, std::sync::atomic::Ordering::SeqCst);
+                                                                                        return;
+                                                                                    }
+                                                                                    Err(e) => {
+                                                                                        tracing::warn!(filter = %hex::encode(&f), error = %e, "app-shard bootstrap: anchor fetch failed");
+                                                                                        flag.store(false, std::sync::atomic::Ordering::SeqCst);
+                                                                                        return;
+                                                                                    }
+                                                                                };
+                                                                                let Some(header) = anchor.header.as_ref() else {
+                                                                                    tracing::warn!(filter = %hex::encode(&f), "app-shard bootstrap: archive anchor has no header");
+                                                                                    flag.store(false, std::sync::atomic::Ordering::SeqCst);
+                                                                                    return;
+                                                                                };
+                                                                                let anchor_frame = header.frame_number;
+                                                                                let expected_roots = header.state_roots.clone();
+                                                                                let predecessor = if anchor_frame > 1 {
+                                                                                    match syncer.get_app_shard_frame(&f, anchor_frame - 1).await {
+                                                                                        Ok(frame) => frame,
+                                                                                        Err(e) => {
+                                                                                            tracing::warn!(filter = %hex::encode(&f), frame = anchor_frame, error = %e, "app-shard bootstrap: predecessor fetch failed");
+                                                                                            flag.store(false, std::sync::atomic::Ordering::SeqCst);
+                                                                                            return;
+                                                                                        }
+                                                                                    }
+                                                                                } else {
+                                                                                    None
+                                                                                };
+                                                                                match syncer.sync_shard_tree(&f, &expected_roots).await {
+                                                                                    Ok(true) => {
+                                                                                        tracing::info!(filter = %hex::encode(&f), anchor_frame, "app-shard bootstrap tree sync converged");
+                                                                                        lb.send(crate::app_engine::AppEngineMessage::ShardBootstrapCompleted { anchor, predecessor });
+                                                                                    }
+                                                                                    Ok(false) => tracing::warn!(filter = %hex::encode(&f), "app-shard bootstrap tree sync did not converge"),
+                                                                                    Err(e) => tracing::warn!(filter = %hex::encode(&f), error = %e, "app-shard bootstrap tree sync failed"),
+                                                                                }
+                                                                            }
                                                                         }
                                                                         flag.store(false, std::sync::atomic::Ordering::SeqCst);
                                                                     });

--- a/crates/quil-node/src/prover_tree_syncer_prod.rs
+++ b/crates/quil-node/src/prover_tree_syncer_prod.rs
@@ -334,4 +334,19 @@ impl ProverTreeSyncer for ProdProverTreeSyncer {
         );
         self.sync_single_shard(l2.to_vec(), expected_roots).await
     }
+
+    async fn get_app_shard_frame(
+        &self,
+        filter: &[u8],
+        frame_number: u64,
+    ) -> Result<Option<quil_types::proto::global::AppShardFrame>> {
+        let addr = self.resolve_addr().await;
+        let mut client = ArchiveClient::connect_mtls(&addr, &self.falcon_signing_key)
+            .await
+            .map_err(|e| QuilError::Internal(format!("archive connect: {e}")))?;
+        client
+            .get_app_shard_frame(filter.to_vec(), frame_number)
+            .await
+            .map_err(|e| QuilError::Internal(format!("get app-shard frame: {e}")))
+    }
 }


### PR DESCRIPTION
## Problem

An app-shard worker with no local materialized frame rejects later CW frames because it cannot verify their declared pre-state without frame N-1. Receiving newer frames therefore cannot recover an empty worker.

## Fix

When a CW worker is behind, this change:

- requests archive ancestor synchronization;
- fetches archive anchor frame N and predecessor N-1;
- synchronizes all four app-state trees to anchor N's declared pre-state roots;
- validates the anchor and predecessor linkage;
- persists N-1 as the local shard-clock head and restarts the CW worker loop.

This lets a worker resume normal contiguous materialization from N rather than requiring replay of the historical app-frame chain. The change also adds archive-bootstrap validation logging.

## Validation

- `cargo test -p quil-engine archive_bootstrap_ --lib`: 3 passed, 0 failed.
- Mainnet evidence: core 2 bootstrapped from archive anchor 14, installed predecessor 13, and retained `mat=13` across restart.

## Scope / non-goals

This fixes the missing-N-1 bootstrap deadlock. It does not resolve the separate historical CW-certificate/committee mismatch currently causing some archive anchors to fail validation; that remains a follow-up investigation.