### PR TITLE
ci: run rust CI on active development branches

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,7 +2,10 @@ name: rust-ci
 
 on:
   push:
-    branches: [develop]
+    # Development moves between `develop`, versioned release branches, and
+    # their milestone branches.  Keep CI on every branch that can be a PR
+    # base so regressions are attributed to the push that introduced them.
+    branches: [develop, 'develop-*', 'v[0-9]*']
   pull_request:
 
 concurrency:


### PR DESCRIPTION
**Base:** `f5b671a6`

`rust-ci.yml` runs three jobs: `build` (`cargo check`), `test` (`cargo nextest`),
and a `release-build` matrix over linux-x86_64, linux-arm64 and macos-arm64.

It has two triggers. `pull_request:` carries no branch filter, so every PR is
covered whatever its base — unchanged here. `push:` was `branches: [develop]`
and nothing else.

Development doesn't land on `develop`. It lands on the versioned branch
(`v2.1.0.25` today) and on milestone branches (`develop-2.1`), which are also
what PRs target. A push to those ran no CI at all, so anything broken there was
first seen by whoever opened the next PR, reported against their branch.

The push trigger becomes `[develop, 'develop-*', 'v[0-9]*']`.

Cost is one run per push to those branches. `concurrency: rust-ci-${{ github.ref }}`
with `cancel-in-progress: true` is already set, so a burst of pushes to one
branch keeps one run rather than queueing.

The red checks here are the LFS budget, not this diff — and they make the point:
a repository-wide fault currently surfaces only on contributors' PRs, never on
the branch that carries it.

Validation: `git diff --check`; the workflow YAML parses.

