### PR TITLE
ci: check all workspace targets before release builds

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   # -----------------------------------------------------------------
-  # build — `cargo check` against the whole workspace.
+  # build — compile every workspace target early, including test-only code.
   # -----------------------------------------------------------------
   build:
     name: build (cargo check)
@@ -45,8 +45,8 @@ jobs:
           shared-key: rust-ci
           cache-on-failure: true
 
-      - name: cargo check --workspace
-        run: cargo check --workspace --locked
+      - name: cargo check --workspace --all-targets
+        run: cargo check --workspace --locked --all-targets
 
   # -----------------------------------------------------------------
   # test — `cargo nextest run` against the whole workspace.


### PR DESCRIPTION
**Base:** `f5b671a6`

The `build` job runs `cargo check --workspace --locked`, and the `release-build`
matrix is gated on it (`needs: build`) so three runners aren't spent on a
workspace that doesn't compile.

`--workspace` checks lib and bin targets only. It does not compile `#[cfg(test)]`
code, integration tests, benches or examples. A change that breaks a test target
therefore leaves `build` green, lets the release matrix start, and fails later in
`test`, where the cause reads as a test failure rather than a compile error.
#613 was exactly that.

`--all-targets` adds those targets to the same check, sharing the `rust-cache`
entry the job already restores. Measured on one host, `--cpus 10 /
CARGO_BUILD_JOBS=6`, `CARGO_INCREMENTAL=0`, off a clean `v2.1.0.25`:

- a PR-shaped run — touch `crates/quil-engine/src/lib.rs`, re-check — is
  **20/21 s without, 24/24 s with**: about **+3.5 s**
- populating the extra targets after a cache miss costs **+34 s** once (44 s vs
  10 s) and **+264 MB** of cache (4.67 GB vs 4.40 GB)
- alternating the two flag sets left the target directory byte-identical, so
  having both forms in play does not thrash the cache

`--all-targets` has compiled cleanly since #619.

Red checks here are the LFS budget, not this diff.

Validation: `git diff --check`; the workflow YAML parses.
