### PR TITLE
fix: wait for CW transport peers before starting app consensus

### DIFF
--- a/crates/quil-engine/src/app_engine.rs
+++ b/crates/quil-engine/src/app_engine.rs
@@ -106,6 +106,10 @@ pub enum AppEngineMessage {
         from: Vec<u8>,
         data: Vec<u8>,
     },
+    /// The master installed the CW subscription and observed a connected peer.
+    /// Do not start simplex before this barrier: earlier messages failed with
+    /// `NoPeersSubscribedToTopic` and were historically discarded.
+    CwTransportReady,
 }
 
 // =====================================================================
@@ -240,6 +244,11 @@ impl AppEngineHandle {
     /// attempts during the halt window are skipped.
     pub fn set_halted(&self, halted: bool) {
         let _ = self.msg_tx.try_send(AppEngineMessage::SetHalted(halted));
+    }
+
+    /// Release the CW startup barrier after the master observes a usable peer.
+    pub fn set_cw_transport_ready(&self) {
+        let _ = self.msg_tx.try_send(AppEngineMessage::CwTransportReady);
     }
 
     /// Read the engine's most-recently-published internal sizes.
@@ -1958,24 +1967,12 @@ impl AppConsensusEngine {
             }
         }
 
-        // Start the shard consensus driver: commonware-simplex (P3) + Falcon.
-        match self.start_consensus_cw((bls_signer_factory)()) {
-            Ok(handle) => {
-                self.cw_handle = Some(handle);
-                info!(
-                    core_id = self.core_id,
-                    filter = hex::encode(&self.filter),
-                    "shard commonware-simplex consensus running (EQUAL VOTES)"
-                );
-            }
-            Err(e) => {
-                warn!(
-                    core_id = self.core_id,
-                    error = %e,
-                    "failed to start shard simplex consensus — will retry (passive until committee is present)"
-                );
-            }
-        }
+        // A CW engine must not emit its first simplex messages until its topic
+        // is subscribed locally and a remote subscriber is present. The master
+        // sends `CwTransportReady` after that condition becomes true.
+        let mut cw_transport_ready = false;
+        info!(core_id = self.core_id, filter = hex::encode(&self.filter),
+            "waiting for CW topic transport readiness before starting consensus");
 
         // Frame cleanup timer — remove stale cached frames every 60s
         let mut cleanup_timer = tokio::time::interval(Duration::from_secs(60));
@@ -2096,6 +2093,20 @@ impl AppConsensusEngine {
                                 }
                             }
                         }
+                        Some(AppEngineMessage::CwTransportReady) => {
+                            if !cw_transport_ready {
+                                cw_transport_ready = true;
+                                match self.start_consensus_cw((bls_signer_factory)()) {
+                                    Ok(handle) => {
+                                        self.cw_handle = Some(handle);
+                                        info!(core_id = self.core_id, filter = hex::encode(&self.filter),
+                                            "shard commonware-simplex consensus running after transport readiness");
+                                    }
+                                    Err(e) => warn!(core_id = self.core_id, error = %e,
+                                        "failed to start shard simplex after transport readiness — will retry"),
+                                }
+                            }
+                        }
                         None => {
                             info!(core_id = self.core_id, "message channel closed");
                             break;
@@ -2112,7 +2123,7 @@ impl AppConsensusEngine {
                 // committee is buildable (the shard's active provers are present
                 // in this node's registry). No-op once running.
                 _ = cw_retry_timer.tick() => {
-                    if self.cw_handle.is_none() {
+                    if cw_transport_ready && self.cw_handle.is_none() {
                         // Passive-mode retry: keep trying until the committee is
                         // buildable (active provers present in this registry).
                         match self.start_consensus_cw((bls_signer_factory)()) {

--- a/crates/quil-engine/src/app_engine.rs
+++ b/crates/quil-engine/src/app_engine.rs
@@ -2123,6 +2123,11 @@ impl AppConsensusEngine {
                 // committee is buildable (the shard's active provers are present
                 // in this node's registry). No-op once running.
                 _ = cw_retry_timer.tick() => {
+                    // This timer also handles dynamic-committee rebuilds below.
+                    // Keep *both* paths behind the transport barrier: otherwise
+                    // a timer tick while CW is still waiting for a subscribed
+                    // peer can instantiate simplex and emit the very startup
+                    // messages that the barrier is meant to prevent.
                     if cw_transport_ready && self.cw_handle.is_none() {
                         // Passive-mode retry: keep trying until the committee is
                         // buildable (active provers present in this registry).
@@ -2143,7 +2148,7 @@ impl AppConsensusEngine {
                                 );
                             }
                         }
-                    } else {
+                    } else if cw_transport_ready {
                         // DYNAMIC COMMITTEE: if the shard's active-prover set
                         // changed since this instance was built (e.g. a prover's
                         // deferred activation reached its epoch, growing a 1-member

--- a/crates/quil-engine/tests/common/mod.rs
+++ b/crates/quil-engine/tests/common/mod.rs
@@ -936,6 +936,15 @@ impl AppShardHarness {
             });
         }
 
+        // The in-memory harness wires every CW peer directly through the event
+        // drains above, so its transport is ready as soon as those drains exist.
+        // Production releases this barrier only after BlossomSub observes a
+        // connected topic subscriber; make the equivalent condition explicit
+        // here rather than letting tests bypass the startup contract.
+        for handle in &all_handles {
+            handle.set_cw_transport_ready();
+        }
+
         Self { filter, workers }
     }
 

--- a/crates/quil-engine/tests/e2e_consensus.rs
+++ b/crates/quil-engine/tests/e2e_consensus.rs
@@ -1886,6 +1886,10 @@ async fn tier2_allocator_spawns_real_engine_on_confirm() {
             }
         });
 
+        // This focused spawn test has no P2P layer. Its local event drain is
+        // already installed, so model the production transport-ready callback
+        // explicitly before returning the worker handle.
+        handle.set_cw_transport_ready();
         handle
     });
 

--- a/crates/quil-engine/tests/e2e_epoch_confirm.rs
+++ b/crates/quil-engine/tests/e2e_epoch_confirm.rs
@@ -1057,6 +1057,10 @@ async fn tier2_composite_end_to_end() {
                 event_drain.lock().push(name.to_string());
             }
         });
+        // This isolated harness has no P2P transport: the local event drain
+        // above is its complete consensus path.  Release the production
+        // transport-ready barrier explicitly once that drain is installed.
+        handle.set_cw_transport_ready();
         handle
     });
 

--- a/crates/quil-node/src/master_node/worker_manager.rs
+++ b/crates/quil-node/src/master_node/worker_manager.rs
@@ -854,6 +854,10 @@ pub(crate) fn init(
                                         });
                                     }
                                     WorkerToMaster::ShardActivated { core_id, filter, handle } => {
+                                        // Keep a second handle for the asynchronous CW transport
+                                        // readiness barrier below; the routing registry owns the
+                                        // original handle.
+                                        let ready_handle = handle.clone();
                                         // Push the current halt state to the
                                         // freshly-activated engine before
                                         // registering it. Without this the
@@ -877,7 +881,6 @@ pub(crate) fn init(
                                         // dispatches never reach the engine.
                                         let p2p = drain_p2p.clone();
                                         let filter_for_sub = filter.clone();
-                                        let ready_handle = handle.clone();
                                         drain_spawner.detach("shard-subscribe", async move {
                                             for topic in [
                                                 quil_engine::bitmasks::shard_frame_bitmask(&filter_for_sub),

--- a/crates/quil-node/src/master_node/worker_manager.rs
+++ b/crates/quil-node/src/master_node/worker_manager.rs
@@ -46,6 +46,13 @@ fn restore_and_fill_worker_pool(
     Ok((restored, created))
 }
 
+/// `NoPeersSubscribedToTopic` is transient during gossip mesh startup; other
+/// publish errors require a different recovery path and must not be retried by
+/// the CW outbox.
+fn retryable_cw_publish_failure(error: &str, attempt: u32) -> bool {
+    error.contains("NoPeersSubscribedToTopic") && attempt < 8
+}
+
 /// Mirror a finalized `AppShardFrame` (canonical `frame_data`) into the master
 /// clock store so the store-backed `AppShardService::get_app_shard_frame` serves
 /// it. Workers commit into their OWN per-worker store (a REMOTE process in
@@ -783,15 +790,22 @@ pub(crate) fn init(
                                         }
                                         let p2p = drain_p2p.clone();
                                         drain_spawner.detach("shard-cw-publish", async move {
-                                            if let Err(e) = p2p
-                                                .publish(
-                                                    quil_engine::bitmasks::shard_cw_bitmask(&filter),
-                                                    quil_engine::bitmasks::shard_cw_frame_payload(channel, &bytes),
-                                                )
-                                                .await
-                                            {
-                                                warn!(core_id, filter = %hex::encode(&filter),
-                                                    error = %e, "shard cw publish failed");
+                                            let topic = quil_engine::bitmasks::shard_cw_bitmask(&filter);
+                                            let payload = quil_engine::bitmasks::shard_cw_frame_payload(channel, &bytes);
+                                            for attempt in 1..=8u32 {
+                                                match p2p.publish(topic.clone(), payload.clone()).await {
+                                                    Ok(()) => break,
+                                                    Err(e) if retryable_cw_publish_failure(&e.to_string(), attempt) => {
+                                                        let delay = std::time::Duration::from_millis(250u64.saturating_mul(1u64 << (attempt - 1)));
+                                                        warn!(core_id, filter = %hex::encode(&filter), attempt, ?delay, error = %e,
+                                                            "shard CW publish has no subscribed peers — retrying");
+                                                        tokio::time::sleep(delay).await;
+                                                    }
+                                                    Err(e) => {
+                                                        warn!(core_id, filter = %hex::encode(&filter), attempt, error = %e, "shard cw publish failed");
+                                                        break;
+                                                    }
+                                                }
                                             }
                                             Ok(())
                                         });
@@ -863,14 +877,48 @@ pub(crate) fn init(
                                         // dispatches never reach the engine.
                                         let p2p = drain_p2p.clone();
                                         let filter_for_sub = filter.clone();
+                                        let ready_handle = handle.clone();
                                         drain_spawner.detach("shard-subscribe", async move {
-                                            p2p.subscribe(quil_engine::bitmasks::shard_frame_bitmask(&filter_for_sub)).await;
-                                            p2p.subscribe(quil_engine::bitmasks::shard_consensus_bitmask(&filter_for_sub)).await;
-                                            p2p.subscribe(quil_engine::bitmasks::shard_prover_bitmask(&filter_for_sub)).await;
-                                            p2p.subscribe(quil_engine::bitmasks::shard_dispatch_bitmask(&filter_for_sub)).await;
+                                            for topic in [
+                                                quil_engine::bitmasks::shard_frame_bitmask(&filter_for_sub),
+                                                quil_engine::bitmasks::shard_consensus_bitmask(&filter_for_sub),
+                                                quil_engine::bitmasks::shard_prover_bitmask(&filter_for_sub),
+                                                quil_engine::bitmasks::shard_dispatch_bitmask(&filter_for_sub),
+                                            ] {
+                                                if let Err(e) = p2p.subscribe_confirmed(topic).await {
+                                                    warn!(core_id, filter = %hex::encode(&filter_for_sub), error = %e,
+                                                        "failed to install shard topic subscription");
+                                                    return Ok(());
+                                                }
+                                            }
                                             // (P3) Subscribe the shard's commonware-simplex topic so
                                             // committee peers' votes/certs/blocks reach this engine.
-                                            p2p.subscribe(quil_engine::bitmasks::shard_cw_bitmask(&filter_for_sub)).await;
+                                            let cw_topic = quil_engine::bitmasks::shard_cw_bitmask(&filter_for_sub);
+                                            if let Err(e) = p2p.subscribe_confirmed(cw_topic.clone()).await {
+                                                warn!(core_id, filter = %hex::encode(&filter_for_sub), error = %e,
+                                                    "failed to install shard CW topic subscription");
+                                                return Ok(());
+                                            }
+                                            let mut wait_logged = false;
+                                            loop {
+                                                match p2p.subscribed_peer_count(cw_topic.clone()).await {
+                                                    Ok(peers) if peers > 0 => {
+                                                        info!(core_id, filter = %hex::encode(&filter_for_sub), peers,
+                                                            "shard CW transport ready; starting consensus engine");
+                                                        ready_handle.set_cw_transport_ready();
+                                                        break;
+                                                    }
+                                                    Ok(_) if !wait_logged => {
+                                                        wait_logged = true;
+                                                        info!(core_id, filter = %hex::encode(&filter_for_sub),
+                                                            "waiting for a subscribed CW peer before starting consensus");
+                                                    }
+                                                    Ok(_) => {}
+                                                    Err(e) => warn!(core_id, filter = %hex::encode(&filter_for_sub), error = %e,
+                                                        "CW transport readiness check failed"),
+                                                }
+                                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                                            }
                                             Ok(())
                                         });
                                         info!(
@@ -1043,6 +1091,14 @@ mod tests {
     use super::*;
     use quil_engine::test_support::TestWorkerManager;
     use quil_engine::worker::WorkerManager as _;
+
+    #[test]
+    fn cw_publish_retry_is_limited_to_missing_topic_peers() {
+        assert!(retryable_cw_publish_failure("blossomsub publish failed: NoPeersSubscribedToTopic", 1));
+        assert!(retryable_cw_publish_failure("NoPeersSubscribedToTopic", 7));
+        assert!(!retryable_cw_publish_failure("NoPeersSubscribedToTopic", 8));
+        assert!(!retryable_cw_publish_failure("p2p command channel closed", 1));
+    }
 
     #[test]
     fn restart_restores_idle_worker_slot_and_fills_missing_cores() {

--- a/crates/quil-p2p/src/blossomsub_behaviour.rs
+++ b/crates/quil-p2p/src/blossomsub_behaviour.rs
@@ -368,6 +368,14 @@ impl BlossomSubBehaviour {
         self.inner.mesh_peers(&topic_for(bitmask).hash()).count()
     }
 
+    /// Connected peers which advertised this exact bitmask. This becomes
+    /// useful before the mesh heartbeat has populated `mesh_peers`.
+    pub fn subscribed_peer_count(&self, bitmask: &[u8]) -> usize {
+        self.peer_subscriptions.iter().filter(|(peer, subscriptions)| {
+            self.connected_peers.contains_key(*peer) && subscriptions.contains(bitmask)
+        }).count()
+    }
+
     /// Read-only access to our own subscription set.
     pub fn subscriptions(&self) -> &HashSet<Vec<u8>> {
         &self.subscriptions
@@ -769,6 +777,20 @@ mod propagation_tests {
             .expect("behaviour")
             .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30)))
             .build()
+    }
+
+    #[test]
+    fn subscribed_peer_count_requires_a_live_exact_subscriber() {
+        let mut behaviour = BlossomSubBehaviour::new(0);
+        let topic = vec![0x0c, 0xa1];
+        let peer = PeerId::random();
+        let disconnected = PeerId::random();
+        behaviour.peer_subscriptions.insert(peer, [topic.clone()].into_iter().collect());
+        behaviour.peer_subscriptions.insert(disconnected, [topic.clone()].into_iter().collect());
+        behaviour.connected_peers.insert(peer, 1);
+
+        assert_eq!(behaviour.subscribed_peer_count(&topic), 1);
+        assert_eq!(behaviour.subscribed_peer_count(&[0x0c, 0xa2]), 0);
     }
 
     /// A message published at the hub reaches every subscribed leaf. Star

--- a/crates/quil-p2p/src/node.rs
+++ b/crates/quil-p2p/src/node.rs
@@ -953,6 +953,13 @@ impl P2PNode {
                             Some(P2PCommand::Subscribe(bitmask)) => {
                                 swarm.behaviour_mut().blossomsub.subscribe(bitmask);
                             }
+                            Some(P2PCommand::SubscribeConfirmed { bitmask, ack }) => {
+                                swarm.behaviour_mut().blossomsub.subscribe(bitmask);
+                                let _ = ack.send(());
+                            }
+                            Some(P2PCommand::SubscribedPeerCount { bitmask, ack }) => {
+                                let _ = ack.send(swarm.behaviour().blossomsub.subscribed_peer_count(&bitmask));
+                            }
                             Some(P2PCommand::Unsubscribe(bitmask)) => {
                                 swarm.behaviour_mut().blossomsub.unsubscribe(&bitmask);
                             }
@@ -1059,6 +1066,22 @@ pub struct P2PHandle {
 impl P2PHandle {
     pub async fn subscribe(&self, bitmask: Vec<u8>) {
         let _ = self.cmd_tx.send(P2PCommand::Subscribe(bitmask)).await;
+    }
+
+    /// Subscribe and wait until the swarm loop has actually applied it.
+    pub async fn subscribe_confirmed(&self, bitmask: Vec<u8>) -> quil_types::error::Result<()> {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        self.cmd_tx.send(P2PCommand::SubscribeConfirmed { bitmask, ack: ack_tx }).await
+            .map_err(|_| QuilError::P2p("p2p command channel closed (swarm shutting down?)".into()))?;
+        ack_rx.await.map_err(|_| QuilError::P2p("p2p swarm dropped subscribe ack (event loop exited)".into()))
+    }
+
+    /// Count connected peers which advertised this exact topic subscription.
+    pub async fn subscribed_peer_count(&self, bitmask: Vec<u8>) -> quil_types::error::Result<usize> {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        self.cmd_tx.send(P2PCommand::SubscribedPeerCount { bitmask, ack: ack_tx }).await
+            .map_err(|_| QuilError::P2p("p2p command channel closed (swarm shutting down?)".into()))?;
+        ack_rx.await.map_err(|_| QuilError::P2p("p2p swarm dropped topic-peer-count ack (event loop exited)".into()))
     }
 
     /// Register a blossomsub-level validator on `bitmask` that filters stale
@@ -1390,6 +1413,8 @@ impl P2PHandle {
 
 enum P2PCommand {
     Subscribe(Vec<u8>),
+    SubscribeConfirmed { bitmask: Vec<u8>, ack: oneshot::Sender<()> },
+    SubscribedPeerCount { bitmask: Vec<u8>, ack: oneshot::Sender<usize> },
     Unsubscribe(Vec<u8>),
     /// Install a per-(source, target) gossip forward filter. Used by the
     /// devnet test proxy to impose bipartite network partitions.


### PR DESCRIPTION
## Summary
- defer app-shard Commonware consensus until the shard topic has at least one subscribed peer
- retain the readiness handle across worker registration and prevent periodic committee rebuilds from bypassing the barrier
- retry the transient `NoPeersSubscribedToTopic` publish result with bounded backoff
- model the readiness signal in both app-shard end-to-end harnesses

## Validation
- Docker Rust workspace suite: 2,965 passed, 21 skipped, 23 slow
- deployed diagnostic node restart: all 15 app workers waited for a subscribed CW peer and were released with 1–2 peers; no app-shard CW publish retry or terminal failure occurred after release

This does not change the unrelated PeerInfo/KeyRegistry startup publications, which can still log `NoPeersSubscribedToTopic` before their own topics acquire peers.