### PR TITLE
fix: distinguish a small shard from an empty one in the size column

### DIFF
--- a/crates/quil-client/src/commands/node/prover/manage/view.rs
+++ b/crates/quil-client/src/commands/node/prover/manage/view.rs
@@ -63,7 +63,7 @@ fn fmt_reward(v: &BigInt) -> String {
 }
 
 fn fmt_mb(v: &BigInt) -> String {
-    format!("{:.1}", bigint_to_f64(v) / (1024.0 * 1024.0))
+    super::super::format_mb(v)
 }
 
 // ── Entry ────────────────────────────────────────────────────────────────

--- a/crates/quil-client/src/commands/node/prover/mod.rs
+++ b/crates/quil-client/src/commands/node/prover/mod.rs
@@ -212,6 +212,26 @@ pub(crate) fn format_storage(bytes: u64) -> String {
     }
 }
 
+/// The `Size [MB]` cell — bytes as megabytes, one decimal, bare number.
+///
+/// The column states its unit in the header so the cells stay short and stay
+/// comparable at a glance; that is worth keeping. What it cost was the bottom
+/// of the range: one decimal of a megabyte resolves to ~52 KB, so every shard
+/// under that printed `0.0`, identical to an empty one.
+///
+/// A non-zero size that would round to `0.0` prints `<0.1` instead. It is an
+/// upper bound in the column's own unit, it right-aligns on the same decimal
+/// column as every other cell, and it sorts and filters as the byte value it
+/// really is — only the rendering changes.
+pub(crate) fn format_mb(v: &BigInt) -> String {
+    let mb = v.to_string().parse::<f64>().unwrap_or(0.0) / (1024.0 * 1024.0);
+    if v.sign() == Sign::Plus && mb < 0.05 {
+        "<0.1".to_string()
+    } else {
+        format!("{mb:.1}")
+    }
+}
+
 /// `formatQUIL` — reward units (1 QUIL = 10^8 units) → 8-decimal string.
 /// NOTE: distinct from the token module's 8e9/12-decimal balance format.
 pub(crate) fn format_quil_reward(raw: &BigInt) -> String {
@@ -242,6 +262,17 @@ mod tests {
         assert_eq!(format_storage(512), "512 B");
         assert_eq!(format_storage(1536), "1.5 KB");
         assert_eq!(format_storage(1024 * 1024), "1.0 MB");
+    }
+
+    #[test]
+    fn format_mb_separates_a_small_shard_from_an_empty_one() {
+        assert_eq!(format_mb(&BigInt::from(0)), "0.0");
+        assert_eq!(format_mb(&BigInt::from(2048)), "<0.1");
+        // The rounding edge: 0.05 MB is where `{:.1}` starts printing `0.1`.
+        assert_eq!(format_mb(&BigInt::from(52_428)), "<0.1");
+        assert_eq!(format_mb(&BigInt::from(52_429)), "0.1");
+        assert_eq!(format_mb(&BigInt::from(5 * 1024 * 1024)), "5.0");
+        assert_eq!(format_mb(&BigInt::from(1024 * 1024 * 1024)), "1024.0");
     }
 
     #[test]


### PR DESCRIPTION
**Base:** `63263c15385d732a65cb3526a5a13c588a23cd57`

`Size [MB]` renders bytes as megabytes with one decimal — about 52 KB of
resolution. Every shard below that prints `0.0`, the same cell an empty shard
gets, so the tail of a size-sorted table is indistinguishable from nothing.

The unit stays in the header, as with `Reward [Q/f]`. That is what keeps the
cells bare numbers, comparable down the column at a glance, and the row short
enough to fit a pane; a per-row suffix would cost both. Precision is not what
the bottom of this column needs — a shard under 52 KB is small, and 2 KB versus
40 KB changes no decision the table supports.

So a non-zero size that would round to `0.0` prints `<0.1`: an upper bound in
the column's own unit, one token wide, right-aligned on the same decimal column
as every other cell. Zero still prints `0.0`, so the two stay distinct. Sorting
and the column filters read the byte value and are untouched — only the
rendering changes.

`format_mb` sits next to `format_storage`, the adaptive-unit formatter it is a
fixed-unit counterpart to, and is tested there.

Independent of #585, which reworks the same table's column sizing: this changes
one line of `view.rs` and the two branches merge without conflict.

`cargo test -p quil-client`: 62 passed, 0 failed.
