### PR TITLE
build: drop variable-level debug info from the test profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,15 @@ debug = false
 # and overflow checks remain on. `cargo build`/`cargo check` are
 # unaffected — they use profile.dev.
 
+# Test binaries keep file/line for every frame — backtraces, panic
+# locations and test failure output are unchanged — but drop the DWARF
+# needed to inspect variables under a debugger.  That debug info is the
+# single largest thing the test profile writes: on a cold
+# `cargo test -p quil-engine --no-run` it accounts for 4.4 GB of a
+# 17.4 GB target directory, 3.4 GB of it in `debug/deps`.
+[profile.test]
+debug = "line-tables-only"
+
 # All third-party dependencies. `*` matches every package except the
 # one currently being built, so workspace members still need explicit
 # overrides below.


### PR DESCRIPTION
Test builds write full DWARF for every crate in the workspace and its dependency graph. On a cold `cargo test -p quil-engine --no-run` that is 4.4 GB of a 17.4 GB target directory — 3.4 GB of it in `debug/deps` — written and linked on every from-scratch build.

`debug = "line-tables-only"` keeps the file and line of every frame, so backtraces, panic locations and test failure output are unchanged. What it drops is variable inspection under a debugger.

Measured on one host, cold, twice into fresh volumes, `--cpus 10 / CARGO_BUILD_JOBS=6`:

| | before | after |
|---|---:|---:|
| target total | 17.4 GB | 13.0 GB |
| `debug/deps` | 11.0 GB | 7.6 GB |
| `debug/incremental` | 2.2 GB | 1.7 GB |
| `quil_engine` test binaries | 1.05 GB | 0.70 GB |
| wall | 529 s | 493 s |

`debug/build` barely moves — those are build-script outputs, not compiled Rust. The wall-time drop is a side effect of writing and linking less, not the point.

This is the profile half of #606. The Taskfile half — the container invocation, and whether `CARGO_INCREMENTAL=0` belongs there as it already does in `rust-ci.yml` — is left open; it is a judgement about how the images are meant to be used. Deliberately not proposing `incremental = false` in the profile: that would penalise iterative native runs to help containerised cold ones.

**Base:** `63263c15385d732a65cb3526a5a13c588a23cd57`

Refs #606
