### PR TITLE
fix: remove duplicate TUI header helper

### DIFF
--- a/crates/quil-client/src/commands/node/prover/manage/view.rs
+++ b/crates/quil-client/src/commands/node/prover/manage/view.rs
@@ -117,36 +117,6 @@ fn col_width(header: &str, cells: impl Iterator<Item = usize>) -> usize {
     cells.max().unwrap_or(0).max(header.len())
 }
 
-/// A column header as printed: sort indicator, name, active-filter marker.
-/// Sizing and rendering share it, so a column is never measured against a
-/// different string than it draws.
-///
-/// `compact` underscores the spaces inside a name. Measured columns sit one
-/// space apart, which leaves `Next Action Default Action` with no way to see
-/// where one header ends; `Next_Action Default_Action` reads unambiguously.
-/// The fixed layout has slack between columns and keeps the spaces.
-fn header_text(
-    name: &str,
-    idx: usize,
-    sort_col: i32,
-    asc: bool,
-    filtered: bool,
-    compact: bool,
-) -> String {
-    let mut s = if compact {
-        name.replace(' ', "_")
-    } else {
-        name.to_string()
-    };
-    if filtered {
-        s.push('*');
-    }
-    if sort_col == idx as i32 {
-        s.insert_str(0, if asc { "^|" } else { "v|" });
-    }
-    s
-}
-
 // ── Entry ────────────────────────────────────────────────────────────────
 
 pub fn draw(f: &mut Frame, m: &mut Model) {


### PR DESCRIPTION
Removes the second `header_text` definition in `crates/quil-client/src/commands/node/prover/manage/view.rs` (lines 128–148 at the current base). The duplicate causes Rust error E0428 and prevents qclient from compiling.