### PR TITLE
fix: atomically install synced subtree blobs

### DIFF
--- a/crates/quil-hypergraph/src/crdt.rs
+++ b/crates/quil-hypergraph/src/crdt.rs
@@ -49,6 +49,59 @@ const PHASE_STR: [(&str, &str); 4] = [
     ("hyperedge", "removes"),
 ];
 
+/// A lock-free forest diff prepared for an atomic sync install.
+///
+/// Remote blobs bound to the changed leaves must be fetched and verified before
+/// the preparation is applied, so a transport failure cannot install a root
+/// whose readable blob state is incomplete.
+pub struct PreparedShardPhaseSync {
+    shard_id: Vec<u8>,
+    phase_idx: usize,
+    target_version: Option<u64>,
+    leaves: Vec<(quil_forest::KeyHash, Vec<u8>)>,
+}
+
+impl PreparedShardPhaseSync {
+    pub fn changed_leaves(&self) -> Vec<([u8; 32], Vec<u8>)> {
+        self.leaves
+            .iter()
+            .map(|(key, value)| (key.0, value.clone()))
+            .collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+}
+
+/// A lock-free authenticated subtree diff prepared for an atomic sync install.
+///
+/// This is the unified-app counterpart of [`PreparedShardPhaseSync`]. Its
+/// source subtree root is authenticated against the pinned app root before
+/// blobs are fetched, and the local subtree is checked after the joint commit.
+pub struct PreparedShardSubtreeSync {
+    app: Vec<u8>,
+    phase_idx: usize,
+    target_version: Option<u64>,
+    bit_path: Vec<bool>,
+    pinned_app_root: Option<[u8; 32]>,
+    source_subtree_root: [u8; 32],
+    leaves: Vec<(quil_forest::KeyHash, Vec<u8>)>,
+}
+
+impl PreparedShardSubtreeSync {
+    pub fn changed_leaves(&self) -> Vec<([u8; 32], Vec<u8>)> {
+        self.leaves
+            .iter()
+            .map(|(key, value)| (key.0, value.clone()))
+            .collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.leaves.is_empty()
+    }
+}
+
 /// Expand a UNIFORM 64-way split `depth` into its complete prefix set: depth 0 ⇒
 /// `[[]]` (single shard); depth 1 ⇒ `{[0]..[63]}` (QUIL); etc. Used by the
 /// convenience [`HypergraphCrdt::set_shard_partition`].
@@ -2037,11 +2090,10 @@ impl HypergraphCrdt {
         Some((v, root))
     }
 
-    /// Forest-sync CLIENT: pull one shard/phase tree from a remote `source` (at
-    /// `source_version`) via the efficient Merkle diff and apply the differing
-    /// leaves into this CRDT's forest at a fresh, COORDINATED version (so it
-    /// doesn't collide with live `commit_inner` versions). Returns the new root
-    /// for the caller to verify against the trusted target.
+    /// Forest-sync CLIENT: prepare one shard/phase Merkle diff from a remote
+    /// `source` at `source_version`, without mutating local state. The caller
+    /// fetches the changed blobs and uses the companion apply method to persist
+    /// both at a fresh coordinated version.
     ///
     /// The diff walk (remote reads) runs LOCK-FREE — it takes neither
     /// `forest_write_lock` nor `commit_lock`. JMT reads are version-exact, so the
@@ -2052,6 +2104,103 @@ impl HypergraphCrdt {
     /// apply: if a commit advanced this phase in between, the diff's leaves are
     /// stale and the apply is aborted for the caller to retry — so an expensive
     /// full-tree diff can never block the global-frame materializer.
+    ///
+    /// Prepare an authenticated phase diff without mutating local state.
+    pub fn prepare_shard_phase_sync<S: quil_forest::TreeReader>(
+        &self,
+        source: &S,
+        source_version: u64,
+        shard_id: &[u8],
+        phase_idx: usize,
+    ) -> Result<PreparedShardPhaseSync> {
+        if phase_idx >= 4 {
+            return Err(QuilError::InvalidArgument("phase_idx >= 4".into()));
+        }
+        let (target_version, leaves) = {
+            let forest = self.forest.read().unwrap();
+            let target_version = self.resolve_phase_version_with(&forest, shard_id, phase_idx);
+            let target = forest.shard_phase_reader(shard_id, PHASES[phase_idx]);
+            let leaves = quil_forest::diff_leaves(
+                source,
+                source_version,
+                &target,
+                target_version.unwrap_or(0),
+            )
+            .map_err(|e| QuilError::Internal(format!("diff_leaves: {e}")))?;
+            (target_version, leaves)
+        };
+        Ok(PreparedShardPhaseSync {
+            shard_id: shard_id.to_vec(),
+            phase_idx,
+            target_version,
+            leaves,
+        })
+    }
+
+    /// Commit a prepared diff only after its remote blobs have been fetched
+    /// and validated. A materializer advance invalidates the preparation.
+    pub fn apply_prepared_shard_phase_sync(
+        &self,
+        prepared: PreparedShardPhaseSync,
+        blob_shard: Option<&ShardKey>,
+        blobs: &[(Vec<u8>, Vec<u8>)],
+    ) -> Result<([u8; 32], u64)> {
+        let _forest_guard = self.forest_write_lock.lock().unwrap();
+        let _guard = self.commit_lock.lock().unwrap();
+        let forest = self.forest.read().unwrap();
+        let current = self.resolve_phase_version_with(
+            &forest,
+            &prepared.shard_id,
+            prepared.phase_idx,
+        );
+        if current != prepared.target_version {
+            return Err(QuilError::Internal(format!(
+                "sync phase {} advanced {:?}→{:?} during blob fetch — retry",
+                prepared.phase_idx, prepared.target_version, current,
+            )));
+        }
+        let version = current.map(|v| v + 1).unwrap_or(0);
+        let (root, puts) = forest
+            .apply_synced_shard_phase(
+                &prepared.shard_id,
+                PHASES[prepared.phase_idx],
+                version,
+                prepared.leaves,
+            )
+            .map_err(|e| QuilError::Internal(format!("apply synced shard: {e}")))?;
+        let txn = self.store.new_transaction(false)?;
+        for (key, value) in puts {
+            txn.set(&key, &value)?;
+        }
+        if let Some((key, value)) = forest.head_version_put(
+            &prepared.shard_id,
+            PHASES[prepared.phase_idx],
+            version,
+        ) {
+            txn.set(&key, &value)?;
+        }
+        if let Some(shard) = blob_shard {
+            let (set, phase) = PHASE_STR[prepared.phase_idx];
+            for (id, blob) in blobs {
+                self.store.save_vertex_underlying_versioned(
+                    txn.as_ref(),
+                    set,
+                    phase,
+                    shard,
+                    id,
+                    blob,
+                    version,
+                )?;
+            }
+        }
+        txn.commit()?;
+        self.phase_versions
+            .write()
+            .unwrap()
+            .insert((prepared.shard_id, prepared.phase_idx), version);
+        Ok((root, version))
+    }
+
     pub fn sync_shard_phase_from<S: quil_forest::TreeReader>(
         &self,
         source: &S,
@@ -2123,16 +2272,130 @@ impl HypergraphCrdt {
         Ok((root, ver, changed))
     }
 
-    /// UNIFIED shard-prover subtree-range sync: pull ONLY the leaves under
-    /// `bit_path` (this prover's shard prefix) from `source`'s app tree and apply
-    /// them to the LOCAL app tree (keyed by `app`), returning the local SUBTREE
-    /// root — the shard commitment. `pinned_app_root` is the trusted header app
-    /// root for the phase; the descent to the prefix is authenticated against it
-    /// (so a peer can't serve a fake subtree), and the applied local subtree root
-    /// is verified to equal the authenticated source subtree root. A shard prover
-    /// thus stores only its subtree yet holds a commitment that composes to the
-    /// global app root — never pulling the whole app. Empty `bit_path` ==
-    /// [`sync_shard_phase_from`] over the whole app tree.
+    /// Prepare an authenticated unified-app subtree diff without mutating local
+    /// state. Call [`apply_prepared_shard_subtree_phase_sync`](Self::apply_prepared_shard_subtree_phase_sync)
+    /// only after every changed leaf's blob has been fetched and verified.
+    pub fn prepare_shard_subtree_phase_sync<S: quil_forest::TreeReader>(
+        &self,
+        source: &S,
+        source_version: u64,
+        app: &[u8],
+        phase_idx: usize,
+        bit_path: &[bool],
+        pinned_app_root: Option<[u8; 32]>,
+    ) -> Result<PreparedShardSubtreeSync> {
+        if phase_idx >= 4 {
+            return Err(QuilError::InvalidArgument("phase_idx >= 4".into()));
+        }
+        let (target_version, leaves, source_subtree_root) = {
+            let forest = self.forest.read().unwrap();
+            let target_version = self.resolve_phase_version_with(&forest, app, phase_idx);
+            let target = forest.shard_phase_reader(app, PHASES[phase_idx]);
+            let (leaves, source_subtree_root) = quil_forest::diff_leaves_under_prefix(
+                source,
+                source_version,
+                &target,
+                target_version.unwrap_or(0),
+                bit_path,
+                pinned_app_root,
+            )
+            .map_err(|e| QuilError::Internal(format!("diff_leaves_under_prefix: {e}")))?;
+            (target_version, leaves, source_subtree_root)
+        };
+        Ok(PreparedShardSubtreeSync {
+            app: app.to_vec(),
+            phase_idx,
+            target_version,
+            bit_path: bit_path.to_vec(),
+            pinned_app_root,
+            source_subtree_root,
+            leaves,
+        })
+    }
+
+    /// Commit a prepared unified-app subtree diff and its verified blobs in one
+    /// transaction. A materializer advance invalidates the preparation.
+    pub fn apply_prepared_shard_subtree_phase_sync(
+        &self,
+        prepared: PreparedShardSubtreeSync,
+        blob_shard: Option<&ShardKey>,
+        blobs: &[(Vec<u8>, Vec<u8>)],
+    ) -> Result<([u8; 32], u64)> {
+        let _forest_guard = self.forest_write_lock.lock().unwrap();
+        let _guard = self.commit_lock.lock().unwrap();
+        let forest = self.forest.read().unwrap();
+        let current = self.resolve_phase_version_with(&forest, &prepared.app, prepared.phase_idx);
+        if current != prepared.target_version {
+            return Err(QuilError::Internal(format!(
+                "sync subtree phase {} advanced {:?}→{:?} during blob fetch — retry",
+                prepared.phase_idx, prepared.target_version, current,
+            )));
+        }
+        if prepared.is_empty() {
+            let version = current.unwrap_or(0);
+            let local = forest
+                .app_subtree_root(&prepared.app, PHASES[prepared.phase_idx], version, &prepared.bit_path)
+                .map_err(|e| QuilError::Internal(format!("app_subtree_root: {e}")))?;
+            if prepared.pinned_app_root.is_some() && local != prepared.source_subtree_root {
+                return Err(QuilError::Internal(
+                    "local subtree root != authenticated source subtree root (no-op path)".into(),
+                ));
+            }
+            return Ok((local, version));
+        }
+        let version = current.map(|v| v + 1).unwrap_or(0);
+        let (_full_root, puts) = forest
+            .apply_synced_shard_phase(
+                &prepared.app,
+                PHASES[prepared.phase_idx],
+                version,
+                prepared.leaves,
+            )
+            .map_err(|e| QuilError::Internal(format!("apply synced subtree: {e}")))?;
+        let txn = self.store.new_transaction(false)?;
+        for (key, value) in puts {
+            txn.set(&key, &value)?;
+        }
+        if let Some((key, value)) = forest.head_version_put(
+            &prepared.app,
+            PHASES[prepared.phase_idx],
+            version,
+        ) {
+            txn.set(&key, &value)?;
+        }
+        if let Some(shard) = blob_shard {
+            let (set, phase) = PHASE_STR[prepared.phase_idx];
+            for (id, blob) in blobs {
+                self.store.save_vertex_underlying_versioned(
+                    txn.as_ref(),
+                    set,
+                    phase,
+                    shard,
+                    id,
+                    blob,
+                    version,
+                )?;
+            }
+        }
+        txn.commit()?;
+        self.phase_versions
+            .write()
+            .unwrap()
+            .insert((prepared.app.clone(), prepared.phase_idx), version);
+        let local = forest
+            .app_subtree_root(&prepared.app, PHASES[prepared.phase_idx], version, &prepared.bit_path)
+            .map_err(|e| QuilError::Internal(format!("app_subtree_root: {e}")))?;
+        if prepared.pinned_app_root.is_some() && local != prepared.source_subtree_root {
+            return Err(QuilError::Internal(
+                "post-sync local subtree root != authenticated source subtree root".into(),
+            ));
+        }
+        Ok((local, version))
+    }
+
+    /// UNIFIED shard-prover subtree-range sync. This compatibility helper
+    /// applies immediately; network callers should prepare, fetch blobs, then
+    /// call [`apply_prepared_shard_subtree_phase_sync`](Self::apply_prepared_shard_subtree_phase_sync).
     pub fn sync_shard_subtree_phase_from<S: quil_forest::TreeReader>(
         &self,
         source: &S,
@@ -2142,80 +2405,18 @@ impl HypergraphCrdt {
         bit_path: &[bool],
         pinned_app_root: Option<[u8; 32]>,
     ) -> Result<([u8; 32], u64, Vec<([u8; 32], Vec<u8>)>)> {
-        if phase_idx >= 4 {
-            return Err(QuilError::InvalidArgument("phase_idx >= 4".into()));
-        }
-        // Lock-free subtree diff + authenticated source subtree root.
-        let (v_t_opt, leaves, src_subtree_root) = {
-            let forest = self.forest.read().unwrap();
-            let v_t_opt = self.resolve_phase_version_with(&forest, app, phase_idx);
-            let target = forest.shard_phase_reader(app, PHASES[phase_idx]);
-            let (leaves, src_root) = quil_forest::diff_leaves_under_prefix(
-                source,
-                source_version,
-                &target,
-                v_t_opt.unwrap_or(0),
-                bit_path,
-                pinned_app_root,
-            )
-            .map_err(|e| QuilError::Internal(format!("diff_leaves_under_prefix: {e}")))?;
-            (v_t_opt, leaves, src_root)
-        };
-        let changed: Vec<([u8; 32], Vec<u8>)> =
-            leaves.iter().map(|(k, v)| (k.0, v.clone())).collect();
-
-        // Nothing to pull — already synced. Return the current local subtree root
-        // without bumping the tree version.
-        if changed.is_empty() {
-            let forest = self.forest.read().unwrap();
-            let ver = v_t_opt.unwrap_or(0);
-            let local = forest
-                .app_subtree_root(app, PHASES[phase_idx], ver, bit_path)
-                .map_err(|e| QuilError::Internal(format!("app_subtree_root: {e}")))?;
-            if pinned_app_root.is_some() && local != src_subtree_root {
-                return Err(QuilError::Internal(
-                    "local subtree root != authenticated source subtree root (no-op path)".into(),
-                ));
-            }
-            return Ok((local, ver, changed));
-        }
-
-        let _forest_guard = self.forest_write_lock.lock().unwrap();
-        let _guard = self.commit_lock.lock().unwrap();
-        let forest = self.forest.read().unwrap();
-        let cur_opt = self.resolve_phase_version_with(&forest, app, phase_idx);
-        if cur_opt != v_t_opt {
-            return Err(QuilError::Internal(format!(
-                "sync subtree phase {phase_idx} advanced {v_t_opt:?}→{cur_opt:?} during diff — retry"
-            )));
-        }
-        let ver = cur_opt.map(|v| v + 1).unwrap_or(0);
-        let (_full_root, puts) = forest
-            .apply_synced_shard_phase(app, PHASES[phase_idx], ver, leaves)
-            .map_err(|e| QuilError::Internal(format!("apply synced subtree: {e}")))?;
-        let txn = self.store.new_transaction(false)?;
-        for (k, v) in puts {
-            txn.set(&k, &v)?;
-        }
-        if let Some((hk, hv)) = forest.head_version_put(app, PHASES[phase_idx], ver) {
-            txn.set(&hk, &hv)?;
-        }
-        txn.commit()?;
-        self.phase_versions.write().unwrap().insert((app.to_vec(), phase_idx), ver);
-
-        // The freshly-applied local subtree root MUST equal the authenticated
-        // source subtree root — this is what binds the pulled leaves to the
-        // trusted header (the pin authenticated the source subtree; this ties our
-        // reconstruction to it).
-        let local = forest
-            .app_subtree_root(app, PHASES[phase_idx], ver, bit_path)
-            .map_err(|e| QuilError::Internal(format!("app_subtree_root: {e}")))?;
-        if pinned_app_root.is_some() && local != src_subtree_root {
-            return Err(QuilError::Internal(
-                "post-sync local subtree root != authenticated source subtree root".into(),
-            ));
-        }
-        Ok((local, ver, changed))
+        let prepared = self.prepare_shard_subtree_phase_sync(
+            source,
+            source_version,
+            app,
+            phase_idx,
+            bit_path,
+            pinned_app_root,
+        )?;
+        let changed = prepared.changed_leaves();
+        let (root, version) =
+            self.apply_prepared_shard_subtree_phase_sync(prepared, None, &[])?;
+        Ok((root, version, changed))
     }
 
     /// The canonical bit-path of one shard `prefix` within an app's COMPLETE

--- a/crates/quil-hypergraph/tests/prover_tree_sync.rs
+++ b/crates/quil-hypergraph/tests/prover_tree_sync.rs
@@ -115,6 +115,120 @@ fn empty_follower_converges_to_leader_prover_root() {
     );
 }
 
+/// A failed blob transfer must not install a matching tree with unreadable
+/// state. Once all blobs are available, tree and blob state become visible
+/// together.
+#[test]
+fn prepared_sync_waits_for_blobs_before_installing_tree() {
+    let leader = fresh_crdt();
+    seed_and_commit(&leader, 1, 1);
+    let follower = fresh_crdt();
+    let shard_id = GLOBAL_APP.to_vec();
+    let (source_version, leader_root) = leader
+        .serve_forest_head(&shard_id, 0)
+        .expect("leader phase head");
+    let reader = InProcTreeReader {
+        source: leader.clone(),
+        shard_id: shard_id.clone(),
+        phase: 0,
+    };
+    let prepared = follower
+        .prepare_shard_phase_sync(&reader, source_version, &shard_id, 0)
+        .expect("prepare sync");
+    assert!(!prepared.is_empty());
+    assert_ne!(
+        follower.compute_shard_root("vertex", "adds", &global_prover_shard()),
+        leader_root,
+        "no tree is installed before the blob transfer succeeds",
+    );
+
+    let blobs = prepared
+        .changed_leaves()
+        .into_iter()
+        .map(|(data, _)| {
+            let mut id = GLOBAL_APP.to_vec();
+            id.extend_from_slice(&data);
+            let blob = leader
+                .peek_synced_blob(&global_prover_shard(), 0, &id)
+                .expect("leader blob");
+            (id, blob)
+        })
+        .collect::<Vec<_>>();
+    follower
+        .apply_prepared_shard_phase_sync(
+            prepared,
+            Some(&global_prover_shard()),
+            &blobs,
+        )
+        .expect("atomic tree-and-blob install");
+    assert_eq!(
+        follower.compute_shard_root("vertex", "adds", &global_prover_shard()),
+        leader_root,
+    );
+}
+
+/// The unified subtree path must have the same ordering guarantee as whole-tree
+/// sync: a failed blob transfer cannot advance the subtree commitment.
+#[test]
+fn prepared_subtree_sync_waits_for_blobs_before_installing_tree() {
+    use quil_types::store::ShardKey;
+
+    let app = *b"quil-app-address-0123456789abcd!";
+    let shard = ShardKey { l1: [0u8; 3], l2: app };
+    let vertex = Location { app_address: app, data_address: [0x00u8; 32] };
+    let leader = fresh_crdt();
+    leader.set_shard_partition(app, 1);
+    leader.set_unified_tree(true);
+    leader.add_vertex(&vertex, b"subtree-data").unwrap();
+    leader.commit(1).unwrap();
+    let leader_root = leader.compute_shard_root("vertex", "adds", &shard);
+    let pinned = <[u8; 32]>::try_from(leader_root.as_slice()).unwrap();
+
+    let follower = fresh_crdt();
+    follower.set_shard_partition(app, 1);
+    follower.set_unified_tree(true);
+    let bit_path = follower.canonical_bits_for_prefix(&app, &[0u32]);
+    let shard_id = app.to_vec();
+    let (source_version, _) = leader
+        .serve_forest_head(&shard_id, 0)
+        .expect("leader phase head");
+    let reader = InProcTreeReader { source: leader.clone(), shard_id, phase: 0 };
+    let prepared = follower
+        .prepare_shard_subtree_phase_sync(
+            &reader,
+            source_version,
+            &app,
+            0,
+            &bit_path,
+            Some(pinned),
+        )
+        .expect("prepare subtree sync");
+    assert!(!prepared.is_empty());
+    assert!(
+        !follower.lookup_vertex(&vertex),
+        "tree and blob state stay absent until blob transfer succeeds",
+    );
+
+    let blobs = prepared
+        .changed_leaves()
+        .into_iter()
+        .map(|(data, _)| {
+            let mut id = app.to_vec();
+            id.extend_from_slice(&data);
+            let blob = leader.peek_synced_blob(&shard, 0, &id).expect("leader blob");
+            (id, blob)
+        })
+        .collect::<Vec<_>>();
+    let (subtree_root, _) = follower
+        .apply_prepared_shard_subtree_phase_sync(prepared, Some(&shard), &blobs)
+        .expect("atomic subtree tree-and-blob install");
+    assert!(follower.lookup_vertex(&vertex), "blob is readable after install");
+    assert_eq!(
+        subtree_root,
+        leader.sub_shard_commitment("vertex", "adds", &shard, &[0u32]).as_slice(),
+    );
+}
+
 /// A follower that is STALE (holds an older subset) converges after sync — the
 /// Merkle diff carries only the missing/changed leaves and reaches the leader root.
 #[test]

--- a/crates/quil-node/src/forest_sync.rs
+++ b/crates/quil-node/src/forest_sync.rs
@@ -49,15 +49,15 @@ async fn fetch_changed_blobs(
     crdt: &Arc<quil_hypergraph::HypergraphCrdt>,
     shard_id: &[u8],
     phase: u32,
-    // Version to REQUEST from the peer (the peer's tree version the diff
-    // addressed — MVCC-pins the served blob so it matches the committed leaf).
+    // Version to request from the peer (the tree version the diff addressed),
+    // which pins each served blob to the authenticated leaf commitment.
     source_version: u64,
-    // Version to SAVE at locally (the version our forest tree was applied at in
-    // `sync_shard_phase_from`) — keeps the blob keyspace consistent with the tree.
-    apply_version: u64,
+    // The local tree version is selected after all blobs are ready; successful
+    // full-tree sync persists them with the tree in one transaction.
     changed: Vec<([u8; 32], Vec<u8>)>,
-) -> Result<()> {
-    let Some(shard) = app_shard_key(shard_id) else { return Ok(()) };
+) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+    let Some(shard) = app_shard_key(shard_id) else { return Ok(Vec::new()); };
+    let mut fetched = Vec::new();
     let shard_key_bytes: Vec<u8> = shard.l1.iter().copied().chain(shard.l2).collect();
     for (kh, leaf_value) in changed {
         // Per-vertex-subtree raw-key model: the changed `key_hash` IS the
@@ -114,10 +114,9 @@ async fn fetch_changed_blobs(
                 hex::encode(&vertex_id)
             )));
         }
-        crdt.save_synced_blob(&shard, phase as usize, &vertex_id, &blob, apply_version)
-            .map_err(|e| QuilError::Internal(format!("save_synced_blob: {e}")))?;
+        fetched.push((vertex_id, blob));
     }
-    Ok(())
+    Ok(fetched)
 }
 
 /// Sync ONE forest tree's phase from a peer: diff + apply the commitment, then
@@ -152,16 +151,22 @@ pub async fn sync_one_phase(
     let remote = RemoteTreeReader::new(client.clone(), handle.clone(), shard_id.to_vec(), phase);
     let c = crdt.clone();
     let sid = shard_id.to_vec();
-    // The forest-write lock is taken INSIDE `sync_shard_phase_from`, around the
-    // apply only — the diff runs lock-free so it can't starve the materializer.
-    let (root, apply_version, changed) = tokio::task::spawn_blocking(move || {
-        c.sync_shard_phase_from(&remote, source_version, &sid, phase as usize)
+    let prepared = tokio::task::spawn_blocking(move || {
+        c.prepare_shard_phase_sync(&remote, source_version, &sid, phase as usize)
+    })
+    .await
+    .map_err(|e| QuilError::Internal(format!("sync task join: {e}")))?
+    .map_err(|e| QuilError::Internal(format!("sync prepare: {e}")))?;
+    let changed = prepared.changed_leaves();
+    let blobs = fetch_changed_blobs(client, crdt, shard_id, phase, source_version, changed).await?;
+    let blob_shard = app_shard_key(shard_id);
+    let c = crdt.clone();
+    let (root, _) = tokio::task::spawn_blocking(move || {
+        c.apply_prepared_shard_phase_sync(prepared, blob_shard.as_ref(), &blobs)
     })
     .await
     .map_err(|e| QuilError::Internal(format!("sync task join: {e}")))?
     .map_err(|e| QuilError::Internal(format!("sync apply: {e}")))?;
-    fetch_changed_blobs(client, crdt, shard_id, phase, source_version, apply_version, changed)
-        .await?;
     Ok(root)
 }
 
@@ -185,8 +190,8 @@ pub async fn sync_subtree_one_phase(
     let remote = RemoteTreeReader::new(client.clone(), handle.clone(), app.to_vec(), phase);
     let c = crdt.clone();
     let app_v = app.to_vec();
-    let (root, apply_version, changed) = tokio::task::spawn_blocking(move || {
-        c.sync_shard_subtree_phase_from(
+    let prepared = tokio::task::spawn_blocking(move || {
+        c.prepare_shard_subtree_phase_sync(
             &remote,
             source_version,
             &app_v,
@@ -197,8 +202,17 @@ pub async fn sync_subtree_one_phase(
     })
     .await
     .map_err(|e| QuilError::Internal(format!("subtree sync task join: {e}")))?
+    .map_err(|e| QuilError::Internal(format!("subtree sync prepare: {e}")))?;
+    let changed = prepared.changed_leaves();
+    let blobs = fetch_changed_blobs(client, crdt, app, phase, source_version, changed).await?;
+    let blob_shard = app_shard_key(app);
+    let c = crdt.clone();
+    let (root, _) = tokio::task::spawn_blocking(move || {
+        c.apply_prepared_shard_subtree_phase_sync(prepared, blob_shard.as_ref(), &blobs)
+    })
+    .await
+    .map_err(|e| QuilError::Internal(format!("subtree sync task join: {e}")))?
     .map_err(|e| QuilError::Internal(format!("subtree sync apply: {e}")))?;
-    fetch_changed_blobs(client, crdt, app, phase, source_version, apply_version, changed).await?;
     Ok(root)
 }
 


### PR DESCRIPTION
## Summary
- prepare forest diffs before any local tree mutation
- fetch and validate changed blobs before committing the prepared full-tree or unified-subtree diff
- persist tree updates and fetched blobs in one transaction
- add regressions for full-tree and unified-subtree ordering

A failed blob transfer can no longer advance a synced root while leaving the corresponding readable state incomplete.

## Tests
- task test_rust_amd64_linux -- -p quil-hypergraph --features test-utils --test prover_tree_sync
- task test_rust_amd64_linux -- -p quil-node
