### PR TITLE
test: handle shard data bootstrap events

### DIFF
--- a/crates/quil-engine/tests/common/mod.rs
+++ b/crates/quil-engine/tests/common/mod.rs
@@ -916,6 +916,11 @@ impl AppShardHarness {
                         E::AncestorSyncRequested { .. } => {
                             events_log.lock().push("AncestorSyncRequested".into());
                         }
+                        E::ShardDataBootstrapRequested { .. } => {
+                            events_log
+                                .lock()
+                                .push("ShardDataBootstrapRequested".into());
+                        }
                         E::ParentSealed { .. } => {
                             events_log.lock().push("ParentSealed".into());
                         }

--- a/crates/quil-engine/tests/e2e_consensus.rs
+++ b/crates/quil-engine/tests/e2e_consensus.rs
@@ -1879,6 +1879,7 @@ async fn tier2_allocator_spawns_real_engine_on_confirm() {
                     EquivocationDetected { .. } => "EquivocationDetected",
                     Halted { .. } => "Halted",
                     AncestorSyncRequested { .. } => "AncestorSyncRequested",
+                    ShardDataBootstrapRequested { .. } => "ShardDataBootstrapRequested",
                     ParentSealed { .. } => "ParentSealed",
                     CwOut { .. } => "CwOut",
                 };

--- a/crates/quil-engine/tests/e2e_epoch_confirm.rs
+++ b/crates/quil-engine/tests/e2e_epoch_confirm.rs
@@ -1051,6 +1051,7 @@ async fn tier2_composite_end_to_end() {
                     EquivocationDetected { .. } => "EquivocationDetected",
                     Halted { .. } => "Halted",
                     AncestorSyncRequested { .. } => "AncestorSyncRequested",
+                    ShardDataBootstrapRequested { .. } => "ShardDataBootstrapRequested",
                     ParentSealed { .. } => "ParentSealed",
                     CwOut { .. } => "CwOut",
                 };


### PR DESCRIPTION
## Summary
- handle ShardDataBootstrapRequested in every app-engine test event drain
- keep test harness event logs exhaustive as app-engine events evolve

## Validation
- task test_rust_amd64_linux -- -p quil-engine (540 passed)