### PR TITLE
fix(node): repair committed leaves whose vertex blob was never stored

### DIFF
--- a/crates/quil-forest/src/forest.rs
+++ b/crates/quil-forest/src/forest.rs
@@ -42,6 +42,18 @@ impl TreeStore {
             }
         }
     }
+
+    /// Every live leaf `(key_hash, value)` of this tree at `version` — see
+    /// [`RocksTreeStore::for_each_live_leaf`].
+    pub fn for_each_live_leaf<F>(&self, version: Version, callback: F) -> Result<usize>
+    where
+        F: FnMut([u8; 32], Vec<u8>),
+    {
+        match self {
+            TreeStore::Rocks(s) => s.for_each_live_leaf(version, callback),
+            TreeStore::Mem(s) => s.for_each_live_leaf(version, callback),
+        }
+    }
 }
 
 impl TreeReader for TreeStore {
@@ -695,6 +707,24 @@ impl Forest {
         self.store(&TreeId::shard_phase(shard_id, phase))
     }
 
+    /// Every live leaf `(key_hash, leaf_value)` of one shard/phase tree at
+    /// `version`. The leaf-blob audit's tree side: the CRDT pairs each emitted
+    /// `commitment ‖ size` with the readable blob keyspace to find leaves this
+    /// node committed but never stored data for.
+    pub fn for_each_shard_phase_leaf<F>(
+        &self,
+        shard_id: &[u8],
+        phase: Phase,
+        version: Version,
+        callback: F,
+    ) -> Result<usize>
+    where
+        F: FnMut([u8; 32], Vec<u8>),
+    {
+        self.store(&TreeId::shard_phase(shard_id, phase))
+            .for_each_live_leaf(version, callback)
+    }
+
     /// SERVER side of forest sync: serve one JMT node of a shard/phase tree.
     /// `node_key` is `borsh(NodeKey)` (as the diff client requests it); returns
     /// `borsh(Node)`, or `None` if the node is absent. Pure proxy over the store —
@@ -1283,6 +1313,127 @@ impl Forest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Run `f` against both backends, so the streaming RocksDB sweep and the
+    /// map-based in-memory one are held to the same contract.
+    fn for_each_backend(f: impl Fn(Forest)) {
+        f(Forest::in_memory());
+        let dir = tempfile::tempdir().unwrap();
+        let mut opts = rocksdb::Options::default();
+        opts.create_if_missing(true);
+        let db = Arc::new(rocksdb::DB::open(&opts, dir.path()).unwrap());
+        f(Forest::with_namespace(db, b"\xF7".to_vec()));
+    }
+
+    fn sorted_leaves(forest: &Forest, shard: &[u8], version: u64) -> Vec<([u8; 32], Vec<u8>)> {
+        let mut out = Vec::new();
+        forest
+            .for_each_shard_phase_leaf(shard, Phase::VertexAdds, version, |kh, v| out.push((kh, v)))
+            .unwrap();
+        out.sort();
+        out
+    }
+
+    /// The leaf-blob audit reads the tree through `for_each_shard_phase_leaf`,
+    /// so it must see EXACTLY the tree as of the version asked for: every live
+    /// key once, at its newest write `<= version`. A sweep that leaked a
+    /// superseded value would make the audit compare a blob against a stale
+    /// commitment and report a healthy vertex as a gap.
+    #[test]
+    fn live_leaf_sweep_is_version_exact_and_deduplicated() {
+        for_each_backend(|forest| {
+            let shard = b"shard-id-0123456789abcdef012345!".to_vec();
+            let key = |i: u8| {
+                let mut k = vec![0u8; 32];
+                k[0] = i;
+                k
+            };
+            // v0: two leaves. v1: one rewritten, one added.
+            forest
+                .commit_shard_phase_raw(
+                    &shard,
+                    Phase::VertexAdds,
+                    0,
+                    vec![(key(1), vec![0xA1]), (key(2), vec![0xA2])],
+                )
+                .unwrap();
+            forest
+                .commit_shard_phase_raw(
+                    &shard,
+                    Phase::VertexAdds,
+                    1,
+                    vec![(key(1), vec![0xB1]), (key(3), vec![0xB3])],
+                )
+                .unwrap();
+
+            let at0 = sorted_leaves(&forest, &shard, 0);
+            assert_eq!(at0.len(), 2, "v0 has exactly the two leaves committed then");
+            let mut want0 = vec![
+                (crate::shard_path_key_hash(&key(1)).0, vec![0xA1]),
+                (crate::shard_path_key_hash(&key(2)).0, vec![0xA2]),
+            ];
+            want0.sort();
+            assert_eq!(at0, want0);
+
+            let at1 = sorted_leaves(&forest, &shard, 1);
+            assert_eq!(at1.len(), 3, "each key emitted ONCE, not once per version");
+            let mut want1 = vec![
+                (crate::shard_path_key_hash(&key(1)).0, vec![0xB1]),
+                (crate::shard_path_key_hash(&key(2)).0, vec![0xA2]),
+                (crate::shard_path_key_hash(&key(3)).0, vec![0xB3]),
+            ];
+            want1.sort();
+            assert_eq!(at1, want1, "the newest write <= version wins per key");
+
+            // A version above the head still reads the head state.
+            assert_eq!(sorted_leaves(&forest, &shard, u64::MAX), at1);
+            // A tree that was never committed sweeps empty rather than erroring.
+            assert!(sorted_leaves(&forest, b"never-committed-shard-id-0123456", 0).is_empty());
+        });
+    }
+
+    /// A deleted key must not be emitted: the audit would otherwise try to
+    /// repair a leaf that no longer exists and could never mark the tree clean.
+    #[test]
+    fn live_leaf_sweep_omits_tombstoned_keys() {
+        for_each_backend(|forest| {
+            let shard = b"shard-id-tombstone-0123456789ab!".to_vec();
+            let key = |i: u8| {
+                let mut k = vec![0u8; 32];
+                k[0] = i;
+                k
+            };
+            forest
+                .commit_shard_phase_raw(
+                    &shard,
+                    Phase::VertexAdds,
+                    0,
+                    vec![(key(1), vec![0xA1]), (key(2), vec![0xA2])],
+                )
+                .unwrap();
+            // Delete key 1 at v1 (a `None` value — the JMT tombstone the raw
+            // commit helper has no spelling for).
+            {
+                let store = forest.store(&TreeId::shard_phase(&shard, Phase::VertexAdds));
+                let tree = Sha256Jmt::new(&store);
+                let (_root, batch) = tree
+                    .put_value_set(vec![(crate::shard_path_key_hash(&key(1)), None)], 1)
+                    .unwrap();
+                store.apply_update(&batch).unwrap();
+            }
+
+            assert_eq!(
+                sorted_leaves(&forest, &shard, 1),
+                vec![(crate::shard_path_key_hash(&key(2)).0, vec![0xA2])],
+                "the tombstoned key is gone at v1",
+            );
+            assert_eq!(
+                sorted_leaves(&forest, &shard, 0).len(),
+                2,
+                "history below the tombstone still reads both leaves",
+            );
+        });
+    }
 
     /// Phase-2 unified tree: `app_subtree_root` reads per-shard commitments as
     /// in-place subtrees of the ONE app tree — nibble-aligned, non-nibble-aligned

--- a/crates/quil-forest/src/store.rs
+++ b/crates/quil-forest/src/store.rs
@@ -79,6 +79,25 @@ impl MemTreeStore {
         self.stale.write().unwrap().clear();
         self.sizes.write().unwrap().clear();
     }
+
+    /// In-memory analogue of [`RocksTreeStore::for_each_live_leaf`]. Emission
+    /// order is unspecified (a `HashMap` sweep); the audit that consumes it is
+    /// order-independent.
+    pub fn for_each_live_leaf<F>(&self, version: Version, mut callback: F) -> Result<usize>
+    where
+        F: FnMut([u8; 32], Vec<u8>),
+    {
+        let mut count = 0usize;
+        for (key_hash, hist) in self.values.read().unwrap().iter() {
+            // Same newest-write-`<= version` rule as `get_value_option`; a
+            // tombstone (`None`) means the key is not live at `version`.
+            if let Some((_, Some(v))) = hist.iter().rev().find(|(ver, _)| *ver <= version) {
+                callback(key_hash.0, v.clone());
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
 }
 
 impl TreeReader for MemTreeStore {
@@ -351,6 +370,69 @@ impl RocksTreeStore {
         let mut it = self.db.raw_iterator_opt(ro);
         it.seek(&lo);
         (it, hi)
+    }
+
+    /// Stream every LIVE leaf of this tree as of `version` — `(key_hash, value)`
+    /// for the newest write `<= version` that is not a tombstone. Returns the
+    /// number emitted.
+    ///
+    /// Value keys are `prefix ++ 'v' ++ key_hash(32) ++ version_be(8)`, so all
+    /// writes of one key are CONTIGUOUS and ascending by version. That lets this
+    /// decide each key during a single sequential sweep with O(1) memory —
+    /// unlike [`seed_size_index_batched`]'s pass 1, which must hold the whole
+    /// map because it joins the value column against the node column.
+    ///
+    /// This is the tree half of the leaf-blob audit: the caller pairs each
+    /// emitted leaf value (`commitment ‖ size`) against the readable blob
+    /// keyspace to find leaves whose data was never stored locally.
+    pub fn for_each_live_leaf<F>(&self, version: Version, mut callback: F) -> Result<usize>
+    where
+        F: FnMut([u8; 32], Vec<u8>),
+    {
+        let khs = self.prefix.len() + 1;
+        let (mut it, hi) = self.seq_iter(TAG_VALUE);
+        let mut count = 0usize;
+        // The key currently being swept and the newest non-tombstone value seen
+        // for it at `<= version` (`None` ⇒ its newest such write was a delete).
+        let mut cur_kh: Option<[u8; 32]> = None;
+        let mut cur_val: Option<Vec<u8>> = None;
+        while it.valid() {
+            let (k, v) = match (it.key(), it.value()) {
+                (Some(k), Some(v)) if k < hi.as_slice() => (k, v),
+                _ => break,
+            };
+            if k.len() != khs + 40 {
+                it.next();
+                continue;
+            }
+            let mut kh = [0u8; 32];
+            kh.copy_from_slice(&k[khs..khs + 32]);
+            let ver = u64::from_be_bytes(k[khs + 32..khs + 40].try_into().unwrap());
+            // Payload: 0x01 ++ value, or 0x00 tombstone.
+            let payload = if ver <= version && v.first() == Some(&0x01) {
+                Some(v[1..].to_vec())
+            } else {
+                None
+            };
+            let ver_in_range = ver <= version;
+            if cur_kh != Some(kh) {
+                if let (Some(prev), Some(val)) = (cur_kh, cur_val.take()) {
+                    callback(prev, val);
+                    count += 1;
+                }
+                cur_kh = Some(kh);
+                cur_val = None;
+            }
+            if ver_in_range {
+                cur_val = payload;
+            }
+            it.next();
+        }
+        if let (Some(prev), Some(val)) = (cur_kh, cur_val) {
+            callback(prev, val);
+            count += 1;
+        }
+        Ok(count)
     }
 
     /// One-time backfill of the `TAG_SIZE` Merkle-sum index over the whole tree at

--- a/crates/quil-hypergraph/src/crdt.rs
+++ b/crates/quil-hypergraph/src/crdt.rs
@@ -249,6 +249,30 @@ pub struct HypergraphCrdt {
     /// flipped at the flag-day frame AFTER the one-time consolidation (§9), since
     /// a split app's existing data lives in the per-prefix trees until then.
     unified_tree: AtomicBool,
+    /// Per-`(shard_id, phase_idx)` leaf-blob audit bookkeeping, so the syncer
+    /// can skip re-sweeping a tree it has already swept. Process-scoped on
+    /// purpose: it is a cost bound, never a correctness claim, and a restart
+    /// re-verifies from disk.
+    blob_audit_state: RwLock<std::collections::HashMap<(Vec<u8>, usize), BlobAuditState>>,
+}
+
+/// Cost-bounding state for one tree's leaf-blob audit. See
+/// [`HypergraphCrdt::missing_vertex_blobs`].
+#[derive(Default)]
+struct BlobAuditState {
+    /// A full audit-and-repair pass has run for this tree in this process, so
+    /// there is nothing left to TRY — every leaf it reported was either filled
+    /// or recorded in `unfillable`. Deliberately not conditioned on the pass
+    /// having filled everything: a permanently unfillable leaf would otherwise
+    /// keep an O(leaves) sweep plus one RPC per gap running on every sync tick
+    /// forever.
+    done: bool,
+    /// Leaves no peer could serve, keyed by the leaf's `key_hash` and holding
+    /// the exact leaf value the fetch was verified against. Storing the VALUE
+    /// rather than just the key is what lets a leaf come back into scope once
+    /// the tree moves it on: a leaf that is stale because our tree has not
+    /// converged is skipped only while it carries that same stale value.
+    unfillable: std::collections::HashMap<[u8; 32], Vec<u8>>,
 }
 
 /// READ-ONLY snapshot of where an app's forest leaves actually live — the
@@ -268,6 +292,21 @@ pub struct AppForestStats {
     pub legacy_nonempty: Vec<(u32, u64)>,
     /// Sum of VertexAdds leaves across ALL 64 legacy per-prefix trees.
     pub legacy_total_vertex_adds: u64,
+}
+
+/// The blob-keyspace [`ShardKey`] for a forest `shard_id`, whose first 32 bytes
+/// are the app address `l2` (the app itself for a single-shard app, or
+/// `app ‖ prefix` for a split sub-shard — the blobs of every sub-shard share the
+/// app's key). `None` when `shard_id` is too short to carry an address. Mirrors
+/// `quil_node::forest_sync::app_shard_key`, which derives the same key on the
+/// sync side; both must agree or a repaired blob lands where no reader looks.
+fn blob_shard_key(shard_id: &[u8]) -> Option<ShardKey> {
+    if shard_id.len() < 32 {
+        return None;
+    }
+    let mut l2 = [0u8; 32];
+    l2.copy_from_slice(&shard_id[..32]);
+    Some(ShardKey { l1: crate::addressing::get_bloom_filter_indices(&l2, 256, 3), l2 })
 }
 
 impl HypergraphCrdt {
@@ -356,6 +395,7 @@ impl HypergraphCrdt {
             covered_prefix: RwLock::new(Vec::new()),
             commit_lock: std::sync::Mutex::new(()),
             unified_tree: AtomicBool::new(false),
+            blob_audit_state: RwLock::new(std::collections::HashMap::new()),
         }
     }
 
@@ -2105,6 +2145,230 @@ impl HypergraphCrdt {
     /// stale and the apply is aborted for the caller to retry — so an expensive
     /// full-tree diff can never block the global-frame materializer.
     ///
+    /// AUDIT: the leaves of `(shard_id, phase_idx)` whose readable vertex blob
+    /// is missing or does not hash to the committed leaf value, as
+    /// `(key_hash, leaf_value)` — the exact shape
+    /// [`PreparedShardPhaseSync::changed_leaves`] produces, so a caller can feed
+    /// the result straight into the ordinary blob-fetch path.
+    ///
+    /// The forest tree and the readable blob keyspace are two separate stores,
+    /// and only the tree is diffed by sync. A sync that installed the tree but
+    /// failed partway through its blob fetch (the pre-atomic
+    /// [`sync_shard_phase_from`](Self::sync_shard_phase_from) path committed the
+    /// tree FIRST and fetched blobs after) leaves leaves with no data. That state
+    /// is self-perpetuating: the root now matches the peer's, so every later sync
+    /// short-circuits and never re-fetches. Only leaves a later frame happens to
+    /// rewrite recover. This is what finds the rest.
+    ///
+    /// Cost is one sequential sweep of the tree's value column plus one point
+    /// read per leaf, so callers should run it once per tree rather than per
+    /// tick — see [`blob_audit_pending`](Self::blob_audit_pending).
+    pub fn missing_vertex_blobs(
+        &self,
+        shard_id: &[u8],
+        phase_idx: usize,
+    ) -> Result<Vec<([u8; 32], Vec<u8>)>> {
+        if phase_idx >= 4 {
+            return Err(QuilError::InvalidArgument("phase_idx >= 4".into()));
+        }
+        let Some(shard) = blob_shard_key(shard_id) else {
+            return Ok(Vec::new());
+        };
+        let leaves: Vec<([u8; 32], Vec<u8>)> = {
+            let forest = self.forest.read().unwrap();
+            let Some(version) = self.resolve_phase_version_with(&forest, shard_id, phase_idx)
+            else {
+                // Never committed here — no leaves, nothing to audit.
+                return Ok(Vec::new());
+            };
+            let mut leaves = Vec::new();
+            forest
+                .for_each_shard_phase_leaf(shard_id, PHASES[phase_idx], version, |kh, v| {
+                    leaves.push((kh, v))
+                })
+                .map_err(|e| QuilError::Internal(format!("leaf sweep: {e}")))?;
+            leaves
+        };
+        // The commitment of the EMPTY blob. A leaf carrying it commits to no
+        // data at all — a removes-phase tombstone (whose leaf keeps the removed
+        // vertex's SIZE but whose blob is empty by construction, see
+        // `stage_sized_tombstone`), or the empty add-side placeholder a remove
+        // stages for a never-added id. There is nothing for a peer to serve for
+        // those, so they are never gaps; auditing them would report every
+        // tombstone forever and no repair could ever clear it.
+        let empty_commitment = quil_tries::vertex_leaf_value(&[])
+            .map_err(|e| QuilError::Internal(format!("vertex_leaf_value: {e}")))?;
+        let mut missing = Vec::new();
+        for (key_hash, leaf_value) in leaves {
+            if leaf_value.len() >= 32 && leaf_value[..32] == empty_commitment[..32] {
+                continue;
+            }
+            // Per-vertex-subtree raw-key model: the leaf's `key_hash` IS the
+            // vertex's 32-byte DATA address, so the blob id is `app ‖ key_hash`.
+            let mut vertex_id = shard.l2.to_vec();
+            vertex_id.extend_from_slice(&key_hash);
+            // Same acceptance test the sync path applies to a served blob: the
+            // stored bytes must hash to the committed `commitment ‖ size`. This
+            // also catches a STALE blob and the EMPTY placeholder standing where
+            // real data belongs — both read as "no data" to every caller.
+            let ok = self
+                .read_blob(&shard, phase_idx, &vertex_id)
+                .and_then(|b| quil_tries::vertex_leaf_value(&b).ok())
+                .map(|recomputed| recomputed == leaf_value)
+                .unwrap_or(false);
+            if !ok {
+                missing.push((key_hash, leaf_value));
+            }
+        }
+        Ok(missing)
+    }
+
+    /// The gaps [`missing_vertex_blobs`](Self::missing_vertex_blobs) reports,
+    /// MINUS the ones a peer has already refused to serve at this exact leaf
+    /// value ([`mark_blob_unfillable`](Self::mark_blob_unfillable)).
+    ///
+    /// This is what a repair pass should iterate. The raw audit is the honest
+    /// answer to "which leaves have no readable data"; this is the answer to
+    /// "which of those is it still worth spending an RPC on". A leaf whose value
+    /// has since changed is dropped from the skip list and offered again, so the
+    /// skip lasts exactly as long as the condition that caused it.
+    pub fn pending_blob_repairs(
+        &self,
+        shard_id: &[u8],
+        phase_idx: usize,
+    ) -> Result<Vec<([u8; 32], Vec<u8>)>> {
+        let missing = self.missing_vertex_blobs(shard_id, phase_idx)?;
+        if missing.is_empty() {
+            return Ok(missing);
+        }
+        let key = (shard_id.to_vec(), phase_idx);
+        let mut state = self.blob_audit_state.write().unwrap();
+        let Some(entry) = state.get_mut(&key) else {
+            return Ok(missing);
+        };
+        if entry.unfillable.is_empty() {
+            return Ok(missing);
+        }
+        let mut out = Vec::with_capacity(missing.len());
+        for (key_hash, leaf_value) in missing {
+            match entry.unfillable.get(&key_hash) {
+                // Same leaf, same failure — do not pay for it again.
+                Some(v) if v == &leaf_value => {}
+                // The leaf moved; the old verdict no longer applies.
+                Some(_) => {
+                    entry.unfillable.remove(&key_hash);
+                    out.push((key_hash, leaf_value));
+                }
+                None => out.push((key_hash, leaf_value)),
+            }
+        }
+        Ok(out)
+    }
+
+    /// Whether `(shard_id, phase_idx)` still needs a leaf-blob audit-and-repair
+    /// pass in this process. Cleared by
+    /// [`mark_blob_audit_done`](Self::mark_blob_audit_done).
+    pub fn blob_audit_pending(&self, shard_id: &[u8], phase_idx: usize) -> bool {
+        !self
+            .blob_audit_state
+            .read()
+            .unwrap()
+            .get(&(shard_id.to_vec(), phase_idx))
+            .is_some_and(|s| s.done)
+    }
+
+    /// Record that `(shard_id, phase_idx)` has been swept and every gap the
+    /// sweep reported was either filled or marked unfillable, so the syncer
+    /// stops paying for it.
+    ///
+    /// Callers MUST only call this after a pass that CONSIDERED every gap — a
+    /// pass cut short by a per-tick budget must leave the tree pending so the
+    /// remainder is picked up on the next tick.
+    pub fn mark_blob_audit_done(&self, shard_id: &[u8], phase_idx: usize) {
+        self.blob_audit_state
+            .write()
+            .unwrap()
+            .entry((shard_id.to_vec(), phase_idx))
+            .or_default()
+            .done = true;
+    }
+
+    /// Record that no peer could serve the blob for `key_hash` while its leaf
+    /// carries `leaf_value`, so
+    /// [`pending_blob_repairs`](Self::pending_blob_repairs) stops offering it.
+    ///
+    /// The common cause is not a missing blob at all but a STALE LEAF: this
+    /// node's tree has not converged, so it commits to a revision the peer no
+    /// longer holds, and the commitment binding correctly rejects the current
+    /// one. Nothing here can fix that — tree convergence will, and when it does
+    /// the leaf value changes and the entry stops matching.
+    pub fn mark_blob_unfillable(
+        &self,
+        shard_id: &[u8],
+        phase_idx: usize,
+        key_hash: [u8; 32],
+        leaf_value: Vec<u8>,
+    ) {
+        self.blob_audit_state
+            .write()
+            .unwrap()
+            .entry((shard_id.to_vec(), phase_idx))
+            .or_default()
+            .unfillable
+            .insert(key_hash, leaf_value);
+    }
+
+    /// REPAIR: store already-verified vertex blobs for `(shard_id, phase_idx)`
+    /// WITHOUT touching the tree — the counterpart to
+    /// [`missing_vertex_blobs`](Self::missing_vertex_blobs). The leaves are
+    /// already committed and already authenticated; only their data was lost, so
+    /// there is no diff to apply and no version to advance.
+    ///
+    /// Blobs are written at the phase's CURRENT version, which is where reads
+    /// (a reverse seek for the greatest version `<= target`) will find them. If
+    /// the materializer concurrently commits a newer version of the same vertex
+    /// it lands ABOVE this write and shadows it, so no lock beyond the write
+    /// transaction is needed.
+    ///
+    /// The caller is responsible for having verified each blob against its
+    /// committed `commitment ‖ size`; this method does not re-derive it.
+    pub fn install_vertex_blobs(
+        &self,
+        shard_id: &[u8],
+        phase_idx: usize,
+        blobs: &[(Vec<u8>, Vec<u8>)],
+    ) -> Result<u64> {
+        if phase_idx >= 4 {
+            return Err(QuilError::InvalidArgument("phase_idx >= 4".into()));
+        }
+        let Some(shard) = blob_shard_key(shard_id) else {
+            return Err(QuilError::InvalidArgument("shard_id shorter than 32 bytes".into()));
+        };
+        if blobs.is_empty() {
+            return Ok(0);
+        }
+        let version = {
+            let forest = self.forest.read().unwrap();
+            self.resolve_phase_version_with(&forest, shard_id, phase_idx)
+                .unwrap_or(0)
+        };
+        let (set, phase) = PHASE_STR[phase_idx];
+        let txn = self.store.new_transaction(false)?;
+        for (id, blob) in blobs {
+            self.store.save_vertex_underlying_versioned(
+                txn.as_ref(),
+                set,
+                phase,
+                &shard,
+                id,
+                blob,
+                version,
+            )?;
+        }
+        txn.commit()?;
+        Ok(version)
+    }
+
     /// Prepare an authenticated phase diff without mutating local state.
     pub fn prepare_shard_phase_sync<S: quil_forest::TreeReader>(
         &self,

--- a/crates/quil-hypergraph/tests/prover_tree_sync.rs
+++ b/crates/quil-hypergraph/tests/prover_tree_sync.rs
@@ -516,3 +516,244 @@ fn resync_when_already_converged_is_stable() {
     let second = sync_prover_phase0(&follower, leader.clone());
     assert_eq!(second, leader_root, "re-sync of a converged follower leaves the root unchanged");
 }
+
+// ---------------------------------------------------------------------------
+// Leaf-blob gap: audit + repair
+// ---------------------------------------------------------------------------
+
+/// The `Location` `seed_and_commit` writes for index `i`.
+fn seeded_location(i: u8) -> Location {
+    let mut data = [0u8; 32];
+    data[0] = i;
+    data[31] = i.wrapping_mul(11);
+    Location { app_address: GLOBAL_APP, data_address: data }
+}
+
+/// Pull `missing`'s blobs from `source` the way `forest_sync::repair_missing_blobs`
+/// does, asserting each one binds to the leaf value the follower committed.
+fn fetch_repair_blobs(
+    source: &HypergraphCrdt,
+    missing: &[([u8; 32], Vec<u8>)],
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    missing
+        .iter()
+        .map(|(key_hash, leaf_value)| {
+            let mut id = GLOBAL_APP.to_vec();
+            id.extend_from_slice(key_hash);
+            let blob = source
+                .peek_synced_blob(&global_prover_shard(), 0, &id)
+                .expect("source serves the blob for a leaf it committed");
+            assert_eq!(
+                &quil_tries::vertex_leaf_value(&blob).unwrap(),
+                leaf_value,
+                "a repair blob must hash to the locally committed commitment‖size",
+            );
+            (id, blob)
+        })
+        .collect()
+}
+
+/// THE REGRESSION. A tree-only install — the pre-atomic sync path, which
+/// committed the commitment first and fetched blobs afterwards, so any error in
+/// the fetch loop left a complete tree with no data behind it — produces a node
+/// whose root is byte-identical to the leader's while every vertex is
+/// unreadable. That state is self-perpetuating: the root check short-circuits
+/// every later sync, the diff transfers nothing, and the hole is permanent.
+///
+/// The audit must find it from local state alone, and the repair must close it
+/// without touching the tree.
+#[test]
+fn tree_only_install_leaves_a_blob_gap_the_audit_finds_and_repair_closes() {
+    let leader = fresh_crdt();
+    seed_and_commit(&leader, 6, 1);
+    let leader_root = leader.compute_shard_root("vertex", "adds", &global_prover_shard());
+    let shard_id = GLOBAL_APP.to_vec();
+
+    let follower = fresh_crdt();
+    let after = sync_prover_phase0(&follower, leader.clone());
+    assert_eq!(after, leader_root, "the tree-only install still reaches the leader root");
+
+    // Invisible to every root-level check — which is exactly why sync can never
+    // notice it: a re-diff against the leader now transfers nothing.
+    for i in 0..6u8 {
+        assert!(
+            !follower.lookup_vertex(&seeded_location(i)),
+            "vertex {i} has a committed leaf but no readable data",
+        );
+    }
+
+    let missing = follower.missing_vertex_blobs(&shard_id, 0).expect("audit");
+    assert_eq!(missing.len(), 6, "the audit finds every leaf whose blob was never stored");
+    assert!(
+        follower.blob_audit_pending(&shard_id, 0),
+        "an unrepaired tree stays pending so the next sync retries",
+    );
+
+    let blobs = fetch_repair_blobs(&leader, &missing);
+    follower.install_vertex_blobs(&shard_id, 0, &blobs).expect("repair install");
+
+    assert!(
+        follower.missing_vertex_blobs(&shard_id, 0).unwrap().is_empty(),
+        "the audit is clean after repair",
+    );
+    for i in 0..6u8 {
+        assert!(follower.lookup_vertex(&seeded_location(i)), "vertex {i} is readable after repair");
+    }
+    assert_eq!(
+        follower.compute_shard_root("vertex", "adds", &global_prover_shard()),
+        leader_root,
+        "repair installs DATA only — the commitment must not move",
+    );
+}
+
+/// A node that materialized its own state has no gaps, so the audit must not
+/// manufacture work: a clean sweep is what lets the syncer mark the tree and
+/// stop paying O(leaves) every tick.
+#[test]
+fn a_fully_materialized_shard_audits_clean() {
+    let crdt = fresh_crdt();
+    seed_and_commit(&crdt, 5, 1);
+    let shard_id = GLOBAL_APP.to_vec();
+
+    assert!(crdt.missing_vertex_blobs(&shard_id, 0).unwrap().is_empty());
+    assert!(crdt.blob_audit_pending(&shard_id, 0), "pending until something marks it");
+    crdt.mark_blob_audit_done(&shard_id, 0);
+    assert!(!crdt.blob_audit_pending(&shard_id, 0), "a clean tree is swept once, not per tick");
+    assert!(
+        crdt.blob_audit_pending(&shard_id, 1),
+        "the mark is per phase — clearing adds must not silence removes",
+    );
+    // A shard this node never committed has nothing to audit.
+    assert!(crdt.missing_vertex_blobs(b"uncommitted-shard-id-0123456789a", 0).unwrap().is_empty());
+}
+
+/// Absence is not the only failure: a blob that does not hash to its committed
+/// leaf reads as no data at all (a stale prior-version blob, or the EMPTY
+/// placeholder a remove stages). The audit must report those too — checking only
+/// for presence is the bug that let a stale blob survive a sync.
+#[test]
+fn audit_reports_a_stored_blob_that_does_not_match_its_commitment() {
+    let leader = fresh_crdt();
+    seed_and_commit(&leader, 3, 1);
+    let shard_id = GLOBAL_APP.to_vec();
+    let follower = fresh_crdt();
+    sync_prover_phase0(&follower, leader.clone());
+
+    let missing = follower.missing_vertex_blobs(&shard_id, 0).unwrap();
+    assert_eq!(missing.len(), 3);
+    let blobs = fetch_repair_blobs(&leader, &missing);
+
+    // Repair two correctly; store vertex 0's blob under vertex 1's id (a
+    // present-but-unbound blob) and an EMPTY blob for the third.
+    let wrong = vec![
+        (blobs[0].0.clone(), blobs[0].1.clone()),
+        (blobs[1].0.clone(), blobs[0].1.clone()),
+        (blobs[2].0.clone(), Vec::new()),
+    ];
+    follower.install_vertex_blobs(&shard_id, 0, &wrong).unwrap();
+
+    let still_missing = follower.missing_vertex_blobs(&shard_id, 0).unwrap();
+    let ids: Vec<[u8; 32]> = still_missing.iter().map(|(kh, _)| *kh).collect();
+    assert_eq!(ids.len(), 2, "both the unbound and the empty blob are still gaps");
+    assert!(ids.contains(&missing[1].0), "the unbound blob is a gap");
+    assert!(ids.contains(&missing[2].0), "the empty placeholder is a gap");
+    assert!(!ids.contains(&missing[0].0), "the correctly repaired vertex is not");
+
+    // The correct blobs close it.
+    follower.install_vertex_blobs(&shard_id, 0, &blobs).unwrap();
+    assert!(follower.missing_vertex_blobs(&shard_id, 0).unwrap().is_empty());
+}
+
+/// A removes-phase tombstone commits a leaf whose blob is empty BY CONSTRUCTION
+/// (`stage_sized_tombstone` keeps the removed vertex's size in the leaf but
+/// stores no data). Auditing those as gaps would report every tombstone forever
+/// and no peer could ever serve a fix, so the sweep would never mark the tree
+/// clean — an unbounded per-tick cost. They must be skipped.
+#[test]
+fn tombstone_leaves_are_never_reported_as_gaps() {
+    let crdt = fresh_crdt();
+    seed_and_commit(&crdt, 4, 1);
+    crdt.remove_vertex(&seeded_location(0)).unwrap();
+    crdt.remove_vertex(&seeded_location(1)).unwrap();
+    crdt.commit(2).unwrap();
+    let shard_id = GLOBAL_APP.to_vec();
+
+    for phase in 0..4 {
+        assert!(
+            crdt.missing_vertex_blobs(&shard_id, phase).unwrap().is_empty(),
+            "phase {phase} of a self-materialized shard with removes must audit clean",
+        );
+    }
+}
+
+/// THE COST BUG THIS GUARDS: a leaf no peer can serve must not keep an
+/// O(leaves) sweep plus one RPC per gap running on every sync tick forever.
+///
+/// The live case is a STALE LEAF — this node's tree has not converged, so it
+/// commits to a revision the peer no longer holds and the commitment binding
+/// correctly rejects the peer's current blob. Measured on L1: 4915 of 5124 gaps
+/// filled, 209 permanently unfillable, and under the original "only a fully
+/// filled audit marks the tree clean" rule those 209 re-ran the entire
+/// nine-and-a-half-minute pass on every tick.
+#[test]
+fn an_unfillable_leaf_is_offered_once_and_then_skipped() {
+    let leader = fresh_crdt();
+    seed_and_commit(&leader, 3, 1);
+    let shard_id = GLOBAL_APP.to_vec();
+    let follower = fresh_crdt();
+    sync_prover_phase0(&follower, leader.clone());
+
+    let missing = follower.pending_blob_repairs(&shard_id, 0).unwrap();
+    assert_eq!(missing.len(), 3, "a tree-only install leaves every leaf without data");
+
+    // A peer serves one of the three; the other two it cannot.
+    let blobs = fetch_repair_blobs(&leader, &missing[..1]);
+    follower.install_vertex_blobs(&shard_id, 0, &blobs).unwrap();
+    for (key_hash, leaf_value) in &missing[1..] {
+        follower.mark_blob_unfillable(&shard_id, 0, *key_hash, leaf_value.clone());
+    }
+
+    // The raw audit still reports them — it is the honest answer about data.
+    assert_eq!(
+        follower.missing_vertex_blobs(&shard_id, 0).unwrap().len(),
+        2,
+        "the audit must not lie about a leaf having no readable data",
+    );
+    // The repair list does not: there is nothing left to spend an RPC on.
+    assert!(
+        follower.pending_blob_repairs(&shard_id, 0).unwrap().is_empty(),
+        "an already-refused leaf must not be requested again",
+    );
+}
+
+/// The skip is bound to the LEAF VALUE, not the leaf. A leaf that was
+/// unfillable because our tree was behind comes back into scope the moment the
+/// tree moves it on — otherwise one transient miss would suppress the repair
+/// for that vertex for the rest of the process.
+#[test]
+fn a_moved_leaf_is_offered_again_after_being_marked_unfillable() {
+    let leader = fresh_crdt();
+    seed_and_commit(&leader, 2, 1);
+    let shard_id = GLOBAL_APP.to_vec();
+    let follower = fresh_crdt();
+    sync_prover_phase0(&follower, leader.clone());
+
+    let missing = follower.pending_blob_repairs(&shard_id, 0).unwrap();
+    assert_eq!(missing.len(), 2);
+    for (key_hash, leaf_value) in &missing {
+        follower.mark_blob_unfillable(&shard_id, 0, *key_hash, leaf_value.clone());
+    }
+    assert!(follower.pending_blob_repairs(&shard_id, 0).unwrap().is_empty());
+
+    // The leader rewrites vertex 0 and the follower's tree converges onto the
+    // new leaf value. The stale verdict no longer describes this leaf.
+    leader.add_vertex(&seeded_location(0), b"rewritten payload for vertex 0").unwrap();
+    leader.commit(2).unwrap();
+    sync_prover_phase0(&follower, leader.clone());
+
+    // The leaf's `key_hash` IS the vertex's data address, so name it directly
+    // rather than relying on the sweep's ordering.
+    let again = follower.pending_blob_repairs(&shard_id, 0).unwrap();
+    assert_eq!(again.len(), 1, "only the leaf that moved is offered again");
+    assert_eq!(again[0].0, seeded_location(0).data_address);
+}

--- a/crates/quil-node/src/forest_sync.rs
+++ b/crates/quil-node/src/forest_sync.rs
@@ -17,7 +17,14 @@ use quil_hypergraph::addressing::get_bloom_filter_indices;
 use quil_rpc::{ArchiveClient, RemoteTreeReader};
 use quil_types::error::{QuilError, Result};
 use quil_types::store::ShardKey;
-use tracing::warn;
+use tracing::{debug, warn};
+
+/// Ceiling on blobs requested by ONE [`repair_missing_blobs`] pass. The fetch is
+/// a sequential RPC per gap running inline in the sync, so the gap list sets the
+/// sync's latency: 5124 gaps measured at ~9.5 minutes on L1. The remainder is
+/// picked up on the next tick, so a large hole still closes — it just does not
+/// stall one sync while it does.
+const MAX_BLOB_REPAIRS_PER_PASS: usize = 2048;
 
 /// `(set, phase)` string pair — the blob keyspace keying, matching the CRDT.
 pub(crate) fn phase_strs(phase: u32) -> (&'static str, &'static str) {
@@ -119,6 +126,160 @@ async fn fetch_changed_blobs(
     Ok(fetched)
 }
 
+/// REPAIR the readable-data half of a shard/phase whose COMMITMENT this node
+/// already holds: audit its committed leaves against the blob keyspace, pull
+/// whatever is missing from `client`, verify each blob against its committed
+/// `commitment ‖ size`, and install it WITHOUT touching the tree.
+///
+/// Why this cannot be left to [`sync_one_phase`]: the diff only transfers leaves
+/// that DIFFER. A node whose tree is byte-identical to the peer's but whose blob
+/// keyspace has holes therefore short-circuits on the root check forever and
+/// never re-fetches the missing data — the hole is permanent, and only vertices
+/// a later frame happens to rewrite recover. Holes of exactly this shape were
+/// produced by the pre-atomic sync install, which committed the tree first and
+/// fetched blobs afterwards, so any error in the fetch loop left a complete tree
+/// with no data behind it. `apply_prepared_shard_phase_sync` stops NEW holes
+/// from forming; it cannot heal one that already exists.
+///
+/// BEST-EFFORT: a peer that will not serve a blob, or serves one that does not
+/// match our committed leaf, is warned about and skipped rather than failing the
+/// sync — the caller's tree is already correct, and repair retries on the next
+/// tick against whichever peer it picks.
+///
+/// BOUNDED: at most [`MAX_BLOB_REPAIRS_PER_PASS`] blobs are requested per call,
+/// because the fetch is one sequential RPC per gap and runs INLINE in
+/// [`sync_one_phase`] — an unbounded pass delays the sync it is attached to for
+/// as long as the gap list is long (5124 gaps measured at ~9.5 minutes). A pass
+/// cut short leaves the tree pending so the next tick continues; a pass that
+/// considered every gap marks it done even if some could not be filled, since
+/// each of those is recorded as unfillable and would otherwise re-run the whole
+/// sweep on every tick forever.
+async fn repair_missing_blobs(
+    client: &mut ArchiveClient,
+    crdt: &Arc<quil_hypergraph::HypergraphCrdt>,
+    shard_id: &[u8],
+    phase: u32,
+    source_version: u64,
+) -> Result<()> {
+    // One sweep per tree per process — the audit is O(leaves) and the steady
+    // state after the first pass must stay free.
+    if !crdt.blob_audit_pending(shard_id, phase as usize) {
+        return Ok(());
+    }
+    let c = crdt.clone();
+    let sid = shard_id.to_vec();
+    let missing =
+        tokio::task::spawn_blocking(move || c.pending_blob_repairs(&sid, phase as usize))
+            .await
+            .map_err(|e| QuilError::Internal(format!("blob audit join: {e}")))??;
+    if missing.is_empty() {
+        crdt.mark_blob_audit_done(shard_id, phase as usize);
+        return Ok(());
+    }
+    let Some(shard) = app_shard_key(shard_id) else { return Ok(()) };
+    let attempting = missing.len().min(MAX_BLOB_REPAIRS_PER_PASS);
+    let deferred = missing.len() - attempting;
+    warn!(
+        phase,
+        shard = %hex::encode(&shard_id[..32.min(shard_id.len())]),
+        gaps = missing.len(),
+        attempting,
+        "committed leaves with missing or mismatched vertex blobs — repairing from peer",
+    );
+    let shard_key_bytes: Vec<u8> = shard.l1.iter().copied().chain(shard.l2).collect();
+    let mut fetched: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut unfilled = 0usize;
+    for (key_hash, leaf_value) in missing.iter().take(attempting) {
+        let mut vertex_id = shard.l2.to_vec();
+        vertex_id.extend_from_slice(key_hash);
+        let blob = match client
+            .get_vertex_blob(shard_key_bytes.clone(), phase, vertex_id.clone(), source_version)
+            .await
+        {
+            Ok(Some(b)) => b,
+            Ok(None) => {
+                crdt.mark_blob_unfillable(
+                    shard_id,
+                    phase as usize,
+                    *key_hash,
+                    leaf_value.clone(),
+                );
+                unfilled += 1;
+                continue;
+            }
+            Err(e) => return Err(QuilError::Internal(format!("get_vertex_blob: {e}"))),
+        };
+        // SECURITY: identical binding to the sync path — the served bytes must
+        // hash to the leaf value THIS node committed, so a peer cannot use the
+        // repair channel to inject data unbound to our authenticated root.
+        //
+        // A mismatch is normally a STALE LEAF on our side rather than a bad
+        // peer: our tree has not converged, so it commits to a revision the peer
+        // no longer holds. Peer versions are per-node counters and cannot
+        // address our revision, so there is nothing to retry — record it against
+        // this leaf value and move on. Tree convergence is what closes these,
+        // and when it does the leaf value changes and the record stops matching.
+        let recomputed = quil_tries::vertex_leaf_value(&blob)
+            .map_err(|e| QuilError::Internal(format!("vertex_leaf_value: {e}")))?;
+        if &recomputed != leaf_value {
+            debug!(
+                phase,
+                vertex = %hex::encode(&vertex_id),
+                "repair blob does not match the locally committed commitment‖size — skipping",
+            );
+            crdt.mark_blob_unfillable(shard_id, phase as usize, *key_hash, leaf_value.clone());
+            unfilled += 1;
+            continue;
+        }
+        fetched.push((vertex_id, blob));
+    }
+    let repaired = fetched.len();
+    if repaired > 0 {
+        let c = crdt.clone();
+        let sid = shard_id.to_vec();
+        tokio::task::spawn_blocking(move || c.install_vertex_blobs(&sid, phase as usize, &fetched))
+            .await
+            .map_err(|e| QuilError::Internal(format!("blob install join: {e}")))??;
+    }
+    // Every gap this pass looked at is now either filled or recorded, so there
+    // is nothing further to try — UNLESS the budget cut the pass short.
+    if deferred == 0 {
+        crdt.mark_blob_audit_done(shard_id, phase as usize);
+    }
+    warn!(phase, repaired, unfilled, deferred, "vertex blob repair pass complete");
+    Ok(())
+}
+
+/// Run [`repair_missing_blobs`] against `client` at ITS current head version,
+/// for paths that ABANDON the anchored pull.
+///
+/// The repair does not depend on the anchor. It works from leaves this node has
+/// already committed and validates every fetched blob against OUR OWN leaf
+/// value, so a peer that cannot serve the anchored version — the common
+/// `resolve_root` miss, where the peer has pruned past the header root we are
+/// pinned to — can still close data holes. Without this the repair would be
+/// gated behind a pull that, on a node stuck in exactly that state, never
+/// succeeds.
+async fn repair_at_peer_head(
+    client: &mut ArchiveClient,
+    crdt: &Arc<quil_hypergraph::HypergraphCrdt>,
+    shard_id: &[u8],
+    phase: u32,
+) {
+    if !crdt.blob_audit_pending(shard_id, phase as usize) {
+        return;
+    }
+    match client.get_forest_head(shard_id.to_vec(), phase).await {
+        Ok(Some((v_s, _))) => {
+            if let Err(e) = repair_missing_blobs(client, crdt, shard_id, phase, v_s).await {
+                warn!(phase, error = %e, "vertex blob repair failed — retrying next sync");
+            }
+        }
+        Ok(None) => {}
+        Err(e) => warn!(phase, error = %e, "head lookup for vertex blob repair failed"),
+    }
+}
+
 /// Sync ONE forest tree's phase from a peer: diff + apply the commitment, then
 /// pull the changed vertices' blobs. Returns the new root (for the caller to
 /// verify, if it has an expected root).
@@ -137,6 +298,18 @@ pub async fn sync_one_phase(
     // doing it). `None` (peer root unknown) always diffs.
     remote_root: Option<[u8; 32]>,
 ) -> Result<[u8; 32]> {
+    // Repair FIRST, before anything that can fail. The blob keyspace is a
+    // separate store the diff never inspects, so a data hole survives both
+    // outcomes below: the root-match short-circuit returns without looking, and
+    // a diff that loses the version race aborts before any blob work. Neither is
+    // rare — a node whose commitment is already correct takes the first path
+    // every tick, and a node catching up takes the second — so gating the repair
+    // on a successful pull leaves it never running on precisely the nodes that
+    // need it. The audit is one sweep per tree per process; afterwards this is a
+    // flag check.
+    if let Err(e) = repair_missing_blobs(client, crdt, shard_id, phase, source_version).await {
+        warn!(phase, error = %e, "vertex blob repair failed — retrying next sync");
+    }
     // (#1) Cheap root-check short-circuit. `compute_shard_root` is a plain
     // forest read (no recompute); when it matches the peer root there is nothing
     // to sync — return it without touching the diff or the forest lock.
@@ -306,6 +479,13 @@ pub async fn sync_shard_phases_verified(
                             anchor = %hex::encode(exp),
                             "peer has no version for the authenticated phase-0 anchor (behind/pruned) — trying another peer",
                         );
+                        // The anchored PULL is off, but the leaf-blob repair is
+                        // not anchored — it fixes leaves we already committed
+                        // and binds each blob to our own leaf value. A node
+                        // whose peers have all pruned past its header anchor
+                        // takes this branch forever, so this is the only place
+                        // its repair can happen.
+                        repair_at_peer_head(&mut client, &crdt, shard_id, phase).await;
                         return Ok(None);
                     }
                     // Auxiliary phase: accept ONLY if the anchor is the peer's
@@ -323,6 +503,7 @@ pub async fn sync_shard_phases_verified(
                                 anchor = %hex::encode(exp),
                                 "peer cannot serve the anchored phase version — trying another peer",
                             );
+                            repair_at_peer_head(&mut client, &crdt, shard_id, phase).await;
                             return Ok(None);
                         }
                     }


### PR DESCRIPTION
Pre-atomic sync could commit a forest leaf before storing its blob. Once roots match, normal diff sync never fetches that missing blob.

Check live leaves for missing blobs, fetch them, and verify `commitment ‖ size` before storing. The repair is bounded and skips sized tombstones.

**Base:** `4eaf1f79f4eb022b9a9d3ccc072064050e5781b6`