### PR TITLE
fix(qclient): give the shard manager one vocabulary and an in-app legend

### DIFF
--- a/crates/quil-client/src/commands/node/prover/epoch.rs
+++ b/crates/quil-client/src/commands/node/prover/epoch.rs
@@ -184,23 +184,6 @@ impl ConfirmWindow {
             WindowState::Missed
         }
     }
-
-    /// `confirmWindow.label` — compact human hint.
-    pub fn label(&self, verb: &str, current_frame: u64, epoch_length: u64) -> String {
-        match self.state(current_frame, epoch_length) {
-            WindowState::Open => format!(
-                "{verb} now (epoch {}, until frame {})",
-                self.confirm_epoch, self.end_frame
-            ),
-            WindowState::Pending => format!(
-                "{verb} @epoch {} (frame {})",
-                self.confirm_epoch, self.start_frame
-            ),
-            WindowState::Missed => {
-                format!("{verb} window missed (was epoch {})", self.confirm_epoch)
-            }
-        }
-    }
 }
 
 /// `allocConfirmWindow` — window for a pending Joining/Leaving allocation.
@@ -213,6 +196,153 @@ pub fn alloc_confirm_window(a: &AllocationTiming, epoch_length: u64) -> Option<C
             Some(ConfirmWindow::for_frame(a.leave_frame, epoch_length))
         }
         _ => None,
+    }
+}
+
+/// The first frame of the epoch after the one `frame` falls in — the
+/// boundary at which an epoch-aligned lifecycle transition takes effect.
+pub fn next_epoch_boundary(frame: u64, epoch_length: u64) -> u64 {
+    epoch_start_frame(epoch_for_frame(frame, epoch_length) + 1, epoch_length)
+}
+
+/// Unit the Next/Default Action thresholds are displayed in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ThresholdUnit {
+    #[default]
+    Frames,
+    Epochs,
+}
+
+impl ThresholdUnit {
+    pub fn toggled(self) -> Self {
+        match self {
+            ThresholdUnit::Frames => ThresholdUnit::Epochs,
+            ThresholdUnit::Epochs => ThresholdUnit::Frames,
+        }
+    }
+}
+
+/// One lifecycle hint: a verb, and — when it is bounded — the frame it falls
+/// due at. Every threshold shown is an epoch boundary, so a single stored
+/// frame renders in either unit. An empty label means "nothing to show".
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ActionHint {
+    pub label: String,
+    pub at_frame: Option<u64>,
+}
+
+impl ActionHint {
+    pub fn none() -> Self {
+        ActionHint::default()
+    }
+
+    pub fn text(label: impl Into<String>) -> Self {
+        ActionHint {
+            label: label.into(),
+            at_frame: None,
+        }
+    }
+
+    pub fn at(label: impl Into<String>, frame: u64) -> Self {
+        ActionHint {
+            label: label.into(),
+            at_frame: Some(frame),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.label.is_empty()
+    }
+
+    /// `verb@f<frame>` or `verb@e<epoch>`; the bare verb when unbounded, which
+    /// for a Next Action reads as "available now".
+    pub fn render(&self, unit: ThresholdUnit, epoch_length: u64) -> String {
+        match self.at_frame {
+            None => self.label.clone(),
+            Some(f) => match unit {
+                ThresholdUnit::Frames => format!("{}@f{}", self.label, f),
+                ThresholdUnit::Epochs => {
+                    format!("{}@e{}", self.label, epoch_for_frame(f, epoch_length))
+                }
+            },
+        }
+    }
+}
+
+/// The Next Action / Default Action hint pair for an allocation.
+///
+/// Next Action lists the key-bound verbs the operator may use (`reject`,
+/// `confirm`, `pause`, `resume`, `leave`), with a threshold when they are not
+/// yet available. Default Action is the single verb the network applies on
+/// its own if the operator does nothing, at the boundary it takes effect.
+/// Both are shared with `qclient node prover status` so the two surfaces
+/// speak the same vocabulary.
+pub fn action_hints(
+    t: &AllocationTiming,
+    eff: EffectiveStatus,
+    epoch_length: u64,
+    current_frame: u64,
+    next_boundary: u64,
+) -> (ActionHint, ActionHint) {
+    match eff {
+        // A proposed join, or a leave nobody has answered yet: confirm or
+        // reject it inside its one-epoch window.
+        EffectiveStatus::Joining if t.raw_status == raw_status::JOINING => {
+            confirm_hints(t, epoch_length, current_frame)
+        }
+        EffectiveStatus::Leaving if t.leave_confirm_frame == 0 => {
+            confirm_hints(t, epoch_length, current_frame)
+        }
+        // A confirmed leave is out of the operator's hands; it departs at the
+        // boundary after the confirmation.
+        EffectiveStatus::Leaving => (
+            ActionHint::none(),
+            ActionHint::at(
+                "depart",
+                next_epoch_boundary(t.leave_confirm_frame, epoch_length),
+            ),
+        ),
+        // A confirmed join short of its activation boundary is already an
+        // ordinary allocation to pause or leave.
+        EffectiveStatus::Joining => (
+            ActionHint::text("(pause|leave)"),
+            ActionHint::at(
+                "activate",
+                next_epoch_boundary(t.join_confirm_frame, epoch_length),
+            ),
+        ),
+        // A stale epoch is recoverable, so its default is the same renewal an
+        // Active allocation gets; the Status column carries the alarm.
+        EffectiveStatus::Active | EffectiveStatus::ExpiredEpoch => {
+            let default = if t.filter.is_empty() {
+                ActionHint::none() // the global filter is exempt from epoch checks
+            } else {
+                ActionHint::at("renew", next_boundary)
+            };
+            (ActionHint::text("(pause|leave)"), default)
+        }
+        EffectiveStatus::Paused => (ActionHint::text("(resume|leave)"), ActionHint::none()),
+        _ => (ActionHint::none(), ActionHint::none()),
+    }
+}
+
+/// Hints for a pending join/leave: both verbs share one window, so they are
+/// grouped under a single threshold, and letting the window close is what
+/// happens by default.
+fn confirm_hints(
+    t: &AllocationTiming,
+    epoch_length: u64,
+    current_frame: u64,
+) -> (ActionHint, ActionHint) {
+    let Some(w) = alloc_confirm_window(t, epoch_length) else {
+        // No proposal frame recorded: nothing gates the answer.
+        return (ActionHint::text("(reject|confirm)"), ActionHint::none());
+    };
+    let expire = ActionHint::at("expire", w.end_frame);
+    match w.state(current_frame, epoch_length) {
+        WindowState::Open => (ActionHint::text("(reject|confirm)"), expire),
+        WindowState::Pending => (ActionHint::at("(reject|confirm)", w.start_frame), expire),
+        WindowState::Missed => (ActionHint::none(), expire),
     }
 }
 

--- a/crates/quil-client/src/commands/node/prover/manage/model.rs
+++ b/crates/quil-client/src/commands/node/prover/manage/model.rs
@@ -11,18 +11,18 @@ use quil_types::proto::node::{
 };
 
 use super::super::epoch::{
-    alloc_confirm_window, compute_effective_status, epoch_for_frame, epoch_len, AllocationTiming,
-    ConfirmWindow, EffectiveStatus, WindowState,
+    action_hints, compute_effective_status, epoch_len, ActionHint, AllocationTiming, ConfirmWindow,
+    EffectiveStatus, ThresholdUnit, WindowState,
 };
 
 // ── Column metadata (shared between rendering and filtering) ─────────────
 
 pub const ALLOC_COL_NAMES: [&str; 15] = [
     "Select", "Filter", "Provers", "Ring", "Size [MB]", "Shards", "Mat", "Lag", "State",
-    "Reward [Q/f]", "Worker", "Status", "Mode", "Next Action", "Default Action",
+    "Reward [Q/d]", "Worker", "Status", "Mode", "Next Action", "Default Action",
 ];
 pub const AVAIL_COL_NAMES: [&str; 10] =
-    ["Select", "Filter", "Provers", "Ring", "Size [MB]", "Shards", "Mat", "Lag", "State", "Reward [Q/f]"];
+    ["Select", "Filter", "Provers", "Ring", "Size [MB]", "Shards", "Mat", "Lag", "State", "Reward [Q/d]"];
 
 pub const ALLOC_FILTERABLE_COLS: [usize; 12] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 pub const AVAIL_FILTERABLE_COLS: [usize; 9] = [1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -75,20 +75,20 @@ pub const PROVERS_WIDTH: usize = 7;
 pub const RING_WIDTH: usize = 5;
 pub const SIZE_WIDTH: usize = 10;
 pub const SHARDS_WIDTH: usize = 7;
-/// Available panel: cells carry a ` Q/f` suffix, so they need the extra room.
 pub const MAT_WIDTH: usize = 9;
 pub const LAG_WIDTH: usize = 6;
 pub const STATE_WIDTH: usize = 8;
-pub const REWARD_WIDTH: usize = 20;
-/// Allocations panel: bare `~<value>` cells.
-pub const ALLOC_REWARD_WIDTH: usize = 14;
+// Header width in both panels; the values are whole QUIL/day.
+pub const REWARD_WIDTH: usize = 12;
+pub const ALLOC_REWARD_WIDTH: usize = 12;
 pub const WORKER_WIDTH: usize = 7;
 pub const STATUS_WIDTH: usize = 12;
 pub const MODE_WIDTH: usize = 4;
-pub const NEXT_ACTION_WIDTH: usize = 30;
-pub const DEFAULT_ACTION_WIDTH: usize = 16;
+// Widest values: `(reject|confirm)@f<8 digits>` and `activate@f<8 digits>`.
+pub const NEXT_ACTION_WIDTH: usize = 26;
+pub const DEFAULT_ACTION_WIDTH: usize = 18;
 
-// 11 spaces between 12 columns, 2 external borders, 2-char sort indicator.
+// 14 spaces between 15 columns, 2 external borders, 1-char sort arrow.
 pub const ALLOC_FIXED_WIDTH: usize = SELECT_WIDTH
     + PROVERS_WIDTH
     + RING_WIDTH
@@ -102,10 +102,10 @@ pub const ALLOC_FIXED_WIDTH: usize = SELECT_WIDTH
     + DEFAULT_ACTION_WIDTH
     + 14
     + 2
-    + 2;
-// 6 spaces between 7 columns, 2 external borders, 2-char sort indicator.
+    + 1;
+// 9 spaces between 10 columns, 2 external borders, 1-char sort arrow.
 pub const AVAIL_FIXED_WIDTH: usize =
-    SELECT_WIDTH + PROVERS_WIDTH + RING_WIDTH + SIZE_WIDTH + SHARDS_WIDTH + MAT_WIDTH + LAG_WIDTH + STATE_WIDTH + REWARD_WIDTH + 9 + 2 + 2;
+    SELECT_WIDTH + PROVERS_WIDTH + RING_WIDTH + SIZE_WIDTH + SHARDS_WIDTH + MAT_WIDTH + LAG_WIDTH + STATE_WIDTH + REWARD_WIDTH + 9 + 2 + 1;
 
 /// Floor for the Filter column in either layout. Filter is what gives way
 /// when the pane cannot hold the table, being the only column whose content
@@ -133,8 +133,8 @@ pub struct AllocationRow {
     pub join_frame: u64,
     pub leave_frame: u64,
     pub worker_id: i64, // core_id, -1 if no worker assigned
-    pub next_action: String,
-    pub default_action: String,
+    pub next_action: ActionHint,
+    pub default_action: ActionHint,
     pub manually_managed: bool,
     // Carried for struct parity with the Go `allocationRow`; not displayed.
     #[allow(dead_code)]
@@ -308,8 +308,16 @@ pub struct Model {
     pub status_sticky: bool,
     pub action_in_flight: bool,
     pub show_help: bool,
+    /// First help line drawn under the pinned title. The help outgrew a
+    /// terminal once it documented every key and every column, and a screen
+    /// that silently loses its bottom half is worse than a short one.
+    pub help_offset: usize,
+    /// Help lines the last frame produced, so scrolling can stop at the end
+    /// without the key handler having to know how the screen is built.
+    pub help_lines: usize,
     pub color_coding: bool,
     pub column_sizing: ColumnSizing,
+    pub threshold_unit: ThresholdUnit,
     pub spinner_frame: usize,
 
     // Load / staleness tracking.
@@ -465,8 +473,7 @@ impl Model {
             allocated_filters.insert(filter_hex.clone());
             let status_name = eff.label().to_string();
 
-            let (next_action, default_action) =
-                action_hints(a, &t, eff, el, ef, next_boundary);
+            let (next_action, default_action) = action_hints(&t, eff, el, ef, next_boundary);
 
             let (wid, mm) = workers
                 .get(&filter_hex)
@@ -533,8 +540,8 @@ impl Model {
                         epoch: 0,
                         last_active_frame: 0,
                         worker_id: w.core_id as i64,
-                        next_action: String::new(),
-                        default_action: String::new(),
+                        next_action: ActionHint::none(),
+                        default_action: ActionHint::none(),
                         manually_managed: w.manually_managed,
                     });
                 }
@@ -657,6 +664,8 @@ impl Model {
         }
         let asc = self.alloc_sort_asc;
         let sel = &self.alloc_selected;
+        let unit = self.threshold_unit;
+        let el = self.epoch_length;
         rows.sort_by(|a, b| {
             let ord = match col {
                 0 => sel.contains(&a.filter_key).cmp(&sel.contains(&b.filter_key)),
@@ -670,8 +679,15 @@ impl Model {
                 8 => materialization_state(a.materialized_frame, a.latest_frame).cmp(materialization_state(b.materialized_frame, b.latest_frame)),
                 9 => a.estimated_reward.cmp(&b.estimated_reward),
                 10 => a.worker_id.cmp(&b.worker_id), 11 => a.status.cmp(&b.status),
-                12 => a.manually_managed.cmp(&b.manually_managed), 13 => a.next_action.cmp(&b.next_action),
-                14 => a.default_action.cmp(&b.default_action),
+                12 => a.manually_managed.cmp(&b.manually_managed),
+                13 => a
+                    .next_action
+                    .render(unit, el)
+                    .cmp(&b.next_action.render(unit, el)),
+                14 => a
+                    .default_action
+                    .render(unit, el)
+                    .cmp(&b.default_action.render(unit, el)),
                 _ => std::cmp::Ordering::Equal,
             };
             if asc {
@@ -1012,72 +1028,135 @@ fn timing(a: &ShardAllocationInfo) -> AllocationTiming<'_> {
     }
 }
 
-/// The `nextAction` / `defaultAction` hint pair for an allocation row
-/// (mirrors the switch in `processRefreshData`).
-fn action_hints(
-    a: &ShardAllocationInfo,
-    t: &AllocationTiming,
-    eff: EffectiveStatus,
-    el: u64,
-    ef: u64,
-    next_boundary: u64,
-) -> (String, String) {
-    if let Some(w) = alloc_confirm_window(t, el) {
-        return match w.state(ef, el) {
-            WindowState::Open => (
-                "reject | confirm now".to_string(),
-                format!("thru f{}", w.end_frame),
-            ),
-            WindowState::Pending => (
-                format!("reject | confirm@f{}", w.start_frame),
-                format!("epoch {}", w.confirm_epoch),
-            ),
-            WindowState::Missed => ("window missed".to_string(), "expired".to_string()),
-        };
-    }
-    match eff {
-        EffectiveStatus::Active => {
-            let default = if !a.filter.is_empty() {
-                format!("renew<f{}", next_boundary)
-            } else {
-                String::new()
-            };
-            ("pause | leave".to_string(), default)
-        }
-        EffectiveStatus::Paused => ("resume | leave".to_string(), String::new()),
-        EffectiveStatus::Joining => {
-            if a.join_confirm_frame_number > 0 {
-                let act_e = epoch_for_frame(a.join_confirm_frame_number, el) + 1;
-                ("confirmed".to_string(), format!("active@e{}", act_e))
-            } else {
-                (String::new(), String::new())
-            }
-        }
-        EffectiveStatus::Leaving => {
-            if a.leave_confirm_frame_number > 0 {
-                let deact_e = epoch_for_frame(a.leave_confirm_frame_number, el) + 1;
-                ("leaving".to_string(), format!("departs@e{}", deact_e))
-            } else {
-                (String::new(), String::new())
-            }
-        }
-        EffectiveStatus::ExpiredEpoch => {
-            ("confirm now (renew)".to_string(), "re-confirm!".to_string())
-        }
-        _ => (String::new(), String::new()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::node::prover::epoch::raw_status;
+
+    const EL: u64 = 720;
+
+    fn alloc(status: u32) -> ShardAllocationInfo {
+        ShardAllocationInfo {
+            filter: vec![0xFF],
+            status,
+            ..Default::default()
+        }
+    }
+
+    fn hints_in(
+        a: &ShardAllocationInfo,
+        current_frame: u64,
+        unit: ThresholdUnit,
+    ) -> (String, String) {
+        let t = timing(a);
+        let eff = compute_effective_status(&t, current_frame, EL);
+        let next_boundary = (current_frame / EL + 1) * EL;
+        let (n, d) = action_hints(&t, eff, EL, current_frame, next_boundary);
+        (n.render(unit, EL), d.render(unit, EL))
+    }
+
+    fn hints(a: &ShardAllocationInfo, current_frame: u64) -> (String, String) {
+        hints_in(a, current_frame, ThresholdUnit::Frames)
+    }
+
+    #[test]
+    fn a_pending_join_groups_both_verbs_under_one_threshold() {
+        let mut a = alloc(raw_status::JOINING);
+        a.join_frame_number = 1117 * EL + 10; // window is epoch 1118
+                                              // Still in epoch 1117: neither verb is available yet.
+        assert_eq!(
+            hints(&a, 1117 * EL + 100),
+            (
+                "(reject|confirm)@f804960".to_string(),
+                "expire@f805680".to_string()
+            )
+        );
+        // Inside epoch 1118: both are available, so the threshold drops.
+        assert_eq!(
+            hints(&a, 1118 * EL + 100),
+            ("(reject|confirm)".to_string(), "expire@f805680".to_string())
+        );
+    }
+
+    #[test]
+    fn every_threshold_reads_in_the_selected_unit() {
+        let mut a = alloc(raw_status::JOINING);
+        a.join_frame_number = 1117 * EL + 10;
+        assert_eq!(
+            hints_in(&a, 1117 * EL + 100, ThresholdUnit::Epochs),
+            (
+                "(reject|confirm)@e1118".to_string(),
+                "expire@e1119".to_string()
+            )
+        );
+        // An unbounded hint is unit-independent.
+        let free = ActionHint::text("(pause|leave)");
+        assert_eq!(free.render(ThresholdUnit::Epochs, EL), "(pause|leave)");
+        assert_eq!(free.render(ThresholdUnit::Frames, EL), "(pause|leave)");
+    }
+
+    #[test]
+    fn an_active_allocation_renews_at_the_next_epoch_boundary() {
+        let mut a = alloc(raw_status::ACTIVE);
+        a.epoch = 1118;
+        assert_eq!(
+            hints(&a, 1118 * EL + 100),
+            ("(pause|leave)".to_string(), "renew@f805680".to_string())
+        );
+    }
+
+    #[test]
+    fn a_stale_epoch_keeps_the_same_renewal_default() {
+        let mut a = alloc(raw_status::ACTIVE);
+        a.epoch = 1117; // missed epoch 1118
+        let t = timing(&a);
+        assert_eq!(
+            compute_effective_status(&t, 1118 * EL + 100, EL),
+            EffectiveStatus::ExpiredEpoch
+        );
+        assert_eq!(
+            hints(&a, 1118 * EL + 100),
+            ("(pause|leave)".to_string(), "renew@f805680".to_string())
+        );
+    }
+
+    #[test]
+    fn a_confirmed_join_activates_at_the_boundary_after_confirmation() {
+        let mut a = alloc(raw_status::ACTIVE);
+        a.epoch = 1118;
+        a.join_confirm_frame_number = 1118 * EL + 5; // activates in epoch 1119
+        assert_eq!(
+            hints(&a, 1118 * EL + 100),
+            ("(pause|leave)".to_string(), "activate@f805680".to_string())
+        );
+    }
+
+    #[test]
+    fn a_confirmed_leave_departs_and_offers_nothing_to_do() {
+        let mut a = alloc(raw_status::LEAVING);
+        a.leave_frame_number = 1117 * EL + 10;
+        a.leave_confirm_frame_number = 1118 * EL + 5; // departs in epoch 1119
+        assert_eq!(
+            hints(&a, 1118 * EL + 100),
+            (String::new(), "depart@f805680".to_string())
+        );
+    }
+
+    #[test]
+    fn a_paused_allocation_has_no_default_transition() {
+        let a = alloc(raw_status::PAUSED);
+        assert_eq!(
+            hints(&a, 1118 * EL + 100),
+            ("(resume|leave)".to_string(), String::new())
+        );
+    }
 
     #[test]
     fn defaults_sort_allocations_by_worker_and_available_by_reward() {
         let m = Model::new();
         assert_eq!(ALLOC_COL_NAMES[m.alloc_sort_col as usize], "Worker");
         assert!(m.alloc_sort_asc);
-        assert_eq!(AVAIL_COL_NAMES[m.avail_sort_col as usize], "Reward [Q/f]");
+        assert_eq!(AVAIL_COL_NAMES[m.avail_sort_col as usize], "Reward [Q/d]");
         assert!(!m.avail_sort_asc);
     }
 }

--- a/crates/quil-client/src/commands/node/prover/manage/update.rs
+++ b/crates/quil-client/src/commands/node/prover/manage/update.rs
@@ -382,6 +382,9 @@ pub fn handle_key(m: &mut Model, ev: KeyEvent) -> Vec<Cmd> {
     if m.join_picker_active {
         return handle_join_picker_key(m, ev);
     }
+    if m.show_help {
+        return handle_help_key(m, ev);
+    }
     if m.filter_edit_active {
         return handle_filter_edit_key(m, ev);
     }
@@ -397,6 +400,31 @@ pub fn handle_key(m: &mut Model, ev: KeyEvent) -> Vec<Cmd> {
     handle_normal_key(m, ev)
 }
 
+/// Help is a full screen of its own, so while it is up the cursor keys page
+/// through it rather than moving a table nobody can see.
+fn handle_help_key(m: &mut Model, ev: KeyEvent) -> Vec<Cmd> {
+    if is_quit(&ev) {
+        return vec![Cmd::Quit];
+    }
+    // One line is the pinned title; the rest is what a page covers.
+    let page = (m.height as usize).saturating_sub(1).max(1);
+    let max = m.help_lines.saturating_sub(page);
+    match ev.code {
+        KeyCode::Char('h') | KeyCode::Esc => {
+            m.show_help = false;
+            m.help_offset = 0;
+        }
+        KeyCode::Up | KeyCode::Char('k') => m.help_offset = m.help_offset.saturating_sub(1),
+        KeyCode::Down | KeyCode::Char('j') => m.help_offset = (m.help_offset + 1).min(max),
+        KeyCode::PageUp => m.help_offset = m.help_offset.saturating_sub(page),
+        KeyCode::PageDown => m.help_offset = (m.help_offset + page).min(max),
+        KeyCode::Home => m.help_offset = 0,
+        KeyCode::End => m.help_offset = max,
+        _ => {}
+    }
+    vec![]
+}
+
 fn handle_normal_key(m: &mut Model, ev: KeyEvent) -> Vec<Cmd> {
     if is_quit(&ev) {
         return vec![Cmd::Quit];
@@ -404,7 +432,8 @@ fn handle_normal_key(m: &mut Model, ev: KeyEvent) -> Vec<Cmd> {
     let c = ch(&ev);
     match ev.code {
         KeyCode::Char('h') => {
-            m.show_help = !m.show_help;
+            m.show_help = true;
+            m.help_offset = 0;
             return vec![];
         }
         KeyCode::Char('C') => {
@@ -416,6 +445,10 @@ fn handle_normal_key(m: &mut Model, ev: KeyEvent) -> Vec<Cmd> {
                 ColumnSizing::Dynamic => ColumnSizing::Fixed,
                 ColumnSizing::Fixed => ColumnSizing::Dynamic,
             };
+            return vec![];
+        }
+        KeyCode::Char('e') => {
+            m.threshold_unit = m.threshold_unit.toggled();
             return vec![];
         }
         KeyCode::Tab => {

--- a/crates/quil-client/src/commands/node/prover/manage/view.rs
+++ b/crates/quil-client/src/commands/node/prover/manage/view.rs
@@ -10,7 +10,8 @@ use ratatui::{
     Frame,
 };
 
-use super::super::{format_quil_daily, format_quil_reward};
+use super::super::epoch::ThresholdUnit;
+use super::super::format_quil_daily_round;
 use super::model::*;
 use super::util::{center_trunc, clamp_offset};
 
@@ -23,6 +24,9 @@ const SUCCESS: Color = Color::Rgb(0x00, 0xff, 0x00);
 const ERROR: Color = Color::Rgb(0xff, 0x00, 0x00);
 const HELP: Color = Color::Rgb(0x88, 0x88, 0x88);
 const FILTER: Color = Color::Rgb(0xff, 0xaa, 0x00);
+/// The sort-direction arrow, so the sorted column is findable at a glance.
+/// Distinct from every status palette above: it marks the layout, not a value.
+const SORT: Color = Color::Rgb(0x55, 0xaa, 0xff);
 
 const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -45,7 +49,19 @@ fn status_color(name: &str) -> Color {
     }
 }
 fn materialization_state_color(state: &str) -> Color {
-    match state { "Current" => SUCCESS, "Lag" | "Unmat" => ERROR, _ => HELP }
+    match state {
+        "Current" => SUCCESS,
+        "Lag" | "Unmat" => ERROR,
+        _ => HELP,
+    }
+}
+
+/// A worker id is only worth colouring when it says the allocation is not
+/// being proved: `-1` is "no worker bound", which is the one value in the
+/// column that asks the operator to do something. Assigned ids are left plain
+/// rather than coloured green, so twelve bound rows stay quiet.
+fn worker_color(worker_id: i64) -> Option<Color> {
+    (worker_id < 0).then_some(ERROR)
 }
 
 fn mode_color(mode: &str) -> Color {
@@ -56,13 +72,23 @@ fn mode_color(mode: &str) -> Color {
     }
 }
 
+/// Sort-direction arrow prefixed to the sorted column's header.
+fn sort_arrow(ascending: bool) -> &'static str {
+    if ascending {
+        "↑"
+    } else {
+        "↓"
+    }
+}
+
 fn spinner(m: &Model) -> &'static str {
     SPINNER[m.spinner_frame % SPINNER.len()]
 }
 
-/// `~` + QUIL reward (8dp), for the reward cell.
+/// Estimated reward for the reward cell: whole QUIL/day, matching the
+/// `Reward [Q/d]` header and the panel-title totals.
 fn fmt_reward(v: &BigInt) -> String {
-    format!("~{}", format_quil_reward(v))
+    format_quil_daily_round(v)
 }
 
 fn fmt_mb(v: &BigInt) -> String {
@@ -94,7 +120,7 @@ fn header_text(
         s.push('*');
     }
     if sort_col == idx as i32 {
-        s.insert_str(0, if asc { "^|" } else { "v|" });
+        s.insert_str(0, sort_arrow(asc));
     }
     s
 }
@@ -114,7 +140,75 @@ fn fit(base: usize, cells: impl Iterator<Item = usize>) -> usize {
 /// a column wider than its content spends the difference on blanks and pushes
 /// the columns to its right off the pane. Measuring is the fix for both.
 fn col_width(header: &str, cells: impl Iterator<Item = usize>) -> usize {
-    cells.max().unwrap_or(0).max(header.len())
+    cells.max().unwrap_or(0).max(printed_width(header))
+}
+
+/// Columns are laid out in terminal cells and `{:>w$}` pads by `char`, so a
+/// width has to be counted the same way. The sort arrow is one character and
+/// three bytes: measuring `len()` would reserve two blanks it never fills.
+fn printed_width(s: &str) -> usize {
+    s.chars().count()
+}
+
+/// Next Action is laid out flush left; every other column stays right.
+///
+/// Right-justifying aligns a column on its tail, which is what you want when
+/// the tail is the part being compared. Default Action always carries a
+/// threshold, so its `@f804960`s line up and the eye reads straight down
+/// them. Next Action does not: `(pause|leave)` has no threshold at all, and
+/// aligned on the tail it lands under the middle of `(reject|confirm)@f804960`
+/// — the column stops looking like one column. Left is the only edge its
+/// values share.
+fn alloc_left_aligned(col: usize) -> bool {
+    col == 13
+}
+
+/// One cell padded to its column width, on the side its column aligns to.
+fn pad_cell(text: &str, width: usize, left: bool) -> String {
+    if left {
+        format!("{text:<width$}")
+    } else {
+        format!("{text:>width$}")
+    }
+}
+
+/// One header cell, as spans.
+///
+/// The sorted column is underlined — an indicator that survives a monochrome
+/// terminal, unlike the arrow's colour — and when colour is on and the cell
+/// isn't already carrying a sort/filter background, the arrow itself is
+/// tinted. Padding is emitted as its own span under the same style so a
+/// highlight background stays contiguous across the whole cell.
+fn header_spans(
+    text: &str,
+    width: usize,
+    base: Style,
+    sorted: bool,
+    tint: bool,
+    left: bool,
+) -> Vec<Span<'static>> {
+    let style = if sorted {
+        base.add_modifier(Modifier::UNDERLINED)
+    } else {
+        base
+    };
+    let blanks = " ".repeat(width.saturating_sub(printed_width(text)));
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(4);
+    if !left && !blanks.is_empty() {
+        spans.push(Span::styled(blanks.clone(), style));
+    }
+    let mut name = text;
+    if tint {
+        if let Some(arrow) = text.chars().next() {
+            spans.push(Span::styled(arrow.to_string(), style.fg(SORT)));
+            name = &text[arrow.len_utf8()..];
+        }
+    }
+    spans.push(Span::styled(name.to_string(), style));
+    if left && !blanks.is_empty() {
+        spans.push(Span::styled(blanks, style));
+    }
+    spans
 }
 
 // ── Entry ────────────────────────────────────────────────────────────────
@@ -197,8 +291,14 @@ fn render_main(f: &mut Frame, m: &mut Model, area: Rect) {
 
     // Actions + status lines.
     let (actions, status) = footer_lines(m);
-    f.render_widget(Paragraph::new(actions).style(Style::new().fg(HELP)), chunks[5]);
-    f.render_widget(Paragraph::new(status).style(Style::new().fg(HELP)), chunks[6]);
+    f.render_widget(
+        Paragraph::new(actions).style(Style::new().fg(HELP)),
+        chunks[5],
+    );
+    f.render_widget(
+        Paragraph::new(status).style(Style::new().fg(HELP)),
+        chunks[6],
+    );
 }
 
 // ── Header ───────────────────────────────────────────────────────────────
@@ -248,13 +348,13 @@ fn alloc_title(m: &Model, sorted: &[AllocationRow]) -> Line<'static> {
     }
     let total = &joining + &active + &paused + &leaving;
     let mut s = format!(
-        "Allocations ({}) Rewards: Total ~{} QUIL/day = Joining ~{} QUIL/day + Active ~{} QUIL/day + Paused ~{} QUIL/day + Leaving ~{} QUIL/day",
+        " Allocations: {}  Estimated Rewards [Q/d]: {} = Joining {} + Active {} + Paused {} + Leaving {}",
         sorted.len(),
-        format_quil_daily(&total),
-        format_quil_daily(&joining),
-        format_quil_daily(&active),
-        format_quil_daily(&paused),
-        format_quil_daily(&leaving),
+        format_quil_daily_round(&total),
+        format_quil_daily_round(&joining),
+        format_quil_daily_round(&active),
+        format_quil_daily_round(&paused),
+        format_quil_daily_round(&leaving),
     );
     if !m.alloc_selected.is_empty() {
         s += &format!(" [{} selected]", m.alloc_selected.len());
@@ -263,7 +363,7 @@ fn alloc_title(m: &Model, sorted: &[AllocationRow]) -> Line<'static> {
 }
 
 fn avail_title(m: &Model, sorted: &[ShardRow]) -> Line<'static> {
-    let mut s = format!(" Available Shards ({})", sorted.len());
+    let mut s = format!(" Available Shards: {}", sorted.len());
     if !m.avail_selected.is_empty() {
         s += &format!(" [{} selected]", m.avail_selected.len());
     }
@@ -284,14 +384,16 @@ fn alloc_cell(m: &Model, a: &AllocationRow, col: usize, fw: usize) -> String {
         4 => fmt_mb(&a.shard_size),
         5 => a.data_shards.to_string(),
         6 => a.materialized_frame.to_string(),
-        7 => materialization_lag(a.materialized_frame, a.latest_frame).map(|v| v.to_string()).unwrap_or_else(|| "-".to_string()),
+        7 => materialization_lag(a.materialized_frame, a.latest_frame)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string()),
         8 => materialization_state(a.materialized_frame, a.latest_frame).to_string(),
         9 => fmt_reward(&a.estimated_reward),
         10 => a.worker_id.to_string(),
         11 => a.status_name.clone(),
         12 => a.mode().to_string(),
-        13 => a.next_action.clone(),
-        _ => a.default_action.clone(),
+        13 => a.next_action.render(m.threshold_unit, m.epoch_length),
+        _ => a.default_action.render(m.threshold_unit, m.epoch_length),
     }
 }
 
@@ -344,14 +446,16 @@ fn alloc_widths_measured(
         .map(|c| {
             col_width(
                 &alloc_header(m, c),
-                sorted.iter().map(|a| alloc_cell(m, a, c, 0).len()),
+                sorted
+                    .iter()
+                    .map(|a| printed_width(&alloc_cell(m, a, c, 0))),
             )
         })
         .collect();
 
     let cap = filter_cap(
         &alloc_header(m, 1),
-        sorted.iter().map(|a| a.filter_hex.len()),
+        sorted.iter().map(|a| printed_width(&a.filter_hex)),
     );
     let fw = filter_width(content_width, &widths, n, cap);
     widths[1] = fw;
@@ -367,11 +471,15 @@ fn alloc_widths_fixed(
 ) -> (Vec<usize>, usize) {
     let shards_w = fit(
         SHARDS_WIDTH,
-        sorted.iter().map(|a| alloc_cell(m, a, 5, 0).len()),
+        sorted
+            .iter()
+            .map(|a| printed_width(&alloc_cell(m, a, 5, 0))),
     );
     let reward_w = fit(
         ALLOC_REWARD_WIDTH,
-        sorted.iter().map(|a| alloc_cell(m, a, 6, 0).len()),
+        sorted
+            .iter()
+            .map(|a| printed_width(&alloc_cell(m, a, 6, 0))),
     );
     // Whatever the wide columns took comes out of the flexible Filter column.
     let grown = (shards_w - SHARDS_WIDTH) + (reward_w - ALLOC_REWARD_WIDTH);
@@ -380,7 +488,10 @@ fn alloc_widths_fixed(
         if col == 1 {
             continue;
         }
-        if m.alloc_col_filters.get(&col).is_some_and(|cf| cf.is_active()) {
+        if m.alloc_col_filters
+            .get(&col)
+            .is_some_and(|cf| cf.is_active())
+        {
             fw = fw.saturating_sub(1);
         }
     }
@@ -392,7 +503,11 @@ fn alloc_widths_fixed(
         PROVERS_WIDTH,
         RING_WIDTH,
         SIZE_WIDTH,
-        shards_w, MAT_WIDTH, LAG_WIDTH, STATE_WIDTH, reward_w,
+        shards_w,
+        MAT_WIDTH,
+        LAG_WIDTH,
+        STATE_WIDTH,
+        reward_w,
         WORKER_WIDTH,
         STATUS_WIDTH,
         MODE_WIDTH,
@@ -403,12 +518,15 @@ fn alloc_widths_fixed(
         if col == 1 {
             continue;
         }
-        if m.alloc_col_filters.get(&col).is_some_and(|cf| cf.is_active()) {
+        if m.alloc_col_filters
+            .get(&col)
+            .is_some_and(|cf| cf.is_active())
+        {
             widths[col] += 1;
         }
     }
     if m.alloc_sort_col >= 0 && (m.alloc_sort_col as usize) < widths.len() {
-        widths[m.alloc_sort_col as usize] += 2;
+        widths[m.alloc_sort_col as usize] += 1;
     }
     (widths, fw)
 }
@@ -451,22 +569,36 @@ fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Ve
     // Header row.
     let mut hdr_spans: Vec<Span> = Vec::new();
     for i in 0..ALLOC_COL_NAMES.len() {
-        let cell = format!("{:>w$}", alloc_header(m, i), w = widths[i]);
-        let style = if m.sort_mode && m.focus.is_alloc() && m.sort_highlight_col == i {
-            Style::new().bg(PRIMARY).fg(TEXT).add_modifier(Modifier::BOLD)
-        } else if m.alloc_filter_mode
+        let hi_sort = m.sort_mode && m.focus.is_alloc() && m.sort_highlight_col == i;
+        let hi_filter = m.alloc_filter_mode
             && !m.filter_edit_active
             && m.focus.is_alloc()
-            && filter_hi == i as i32
-        {
-            Style::new().bg(FILTER).fg(TEXT).add_modifier(Modifier::BOLD)
+            && filter_hi == i as i32;
+        let style = if hi_sort {
+            Style::new()
+                .bg(PRIMARY)
+                .fg(TEXT)
+                .add_modifier(Modifier::BOLD)
+        } else if hi_filter {
+            Style::new()
+                .bg(FILTER)
+                .fg(TEXT)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::new().add_modifier(Modifier::BOLD)
         };
+        let sorted = m.alloc_sort_col == i as i32;
         if i > 0 {
             hdr_spans.push(Span::raw(" "));
         }
-        hdr_spans.push(Span::styled(cell, style));
+        hdr_spans.extend(header_spans(
+            &alloc_header(m, i),
+            widths[i],
+            style,
+            sorted,
+            sorted && m.color_coding && !hi_sort && !hi_filter,
+            alloc_left_aligned(i),
+        ));
     }
     let mut lines = vec![Line::from(hdr_spans)];
 
@@ -479,7 +611,7 @@ fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Ve
         let selected = i == m.alloc_cursor && m.focus.is_alloc();
 
         let cells: Vec<String> = (0..widths.len())
-            .map(|c| format!("{:>w$}", alloc_cell(m, a, c, fw), w = widths[c]))
+            .map(|c| pad_cell(&alloc_cell(m, a, c, fw), widths[c], alloc_left_aligned(c)))
             .collect();
 
         if selected {
@@ -495,9 +627,25 @@ fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Ve
                 if ci > 0 {
                     spans.push(Span::raw(" "));
                 }
+                let mat_color = || {
+                    materialization_state_color(materialization_state(
+                        a.materialized_frame,
+                        a.latest_frame,
+                    ))
+                };
                 let span = match ci {
-                    3 if m.color_coding => Span::styled(cell.clone(), Style::new().fg(ring_color(a.ring))),
-                    8 if m.color_coding => Span::styled(cell.clone(), Style::new().fg(materialization_state_color(materialization_state(a.materialized_frame, a.latest_frame)))),
+                    3 if m.color_coding => {
+                        Span::styled(cell.clone(), Style::new().fg(ring_color(a.ring)))
+                    }
+                    // Mat, Lag and State are three readings of one fact, so
+                    // they take one colour: whichever the State cell shows.
+                    6 | 7 | 8 if m.color_coding => {
+                        Span::styled(cell.clone(), Style::new().fg(mat_color()))
+                    }
+                    10 if m.color_coding => match worker_color(a.worker_id) {
+                        Some(color) => Span::styled(cell.clone(), Style::new().fg(color)),
+                        None => Span::raw(cell.clone()),
+                    },
                     11 if m.color_coding => {
                         Span::styled(cell.clone(), Style::new().fg(status_color(&a.status_name)))
                     }
@@ -522,7 +670,7 @@ fn render_alloc_panel(m: &mut Model, sorted: &[AllocationRow], area: Rect) -> Ve
 /// reward differently from the rest — megabytes against an adaptive unit, a
 /// bare reward against one suffixed ` Q/f` — so moving the cursor changed the
 /// value under it, and the unsuffixed variants disagreed with the `Size [MB]`
-/// and `Reward [Q/f]` headers that were already stating those units. One
+/// and `Reward [Q/d]` headers that were already stating those units. One
 /// rendering per cell settles both, and drops the widest reward cell from 15
 /// columns to 12.
 fn avail_cell(m: &Model, s: &ShardRow, col: usize, fw: usize) -> String {
@@ -534,7 +682,9 @@ fn avail_cell(m: &Model, s: &ShardRow, col: usize, fw: usize) -> String {
         4 => fmt_mb(&s.shard_size),
         5 => s.data_shards.to_string(),
         6 => s.materialized_frame.to_string(),
-        7 => materialization_lag(s.materialized_frame, s.latest_frame).map(|v| v.to_string()).unwrap_or_else(|| "-".to_string()),
+        7 => materialization_lag(s.materialized_frame, s.latest_frame)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string()),
         8 => materialization_state(s.materialized_frame, s.latest_frame).to_string(),
         _ => fmt_reward(&s.estimated_reward),
     }
@@ -579,14 +729,16 @@ fn avail_widths_measured(
         .map(|c| {
             col_width(
                 &avail_header(m, c),
-                sorted.iter().map(|s| avail_cell(m, s, c, 0).len()),
+                sorted
+                    .iter()
+                    .map(|s| printed_width(&avail_cell(m, s, c, 0))),
             )
         })
         .collect();
 
     let cap = filter_cap(
         &avail_header(m, 1),
-        sorted.iter().map(|s| s.filter_hex.len()),
+        sorted.iter().map(|s| printed_width(&s.filter_hex)),
     );
     let fw = filter_width(content_width, &widths, n, cap);
     widths[1] = fw;
@@ -596,11 +748,15 @@ fn avail_widths_measured(
 fn avail_widths_fixed(m: &Model, content_width: usize, sorted: &[ShardRow]) -> (Vec<usize>, usize) {
     let shards_w = fit(
         SHARDS_WIDTH,
-        sorted.iter().map(|s| avail_cell(m, s, 5, 0).len()),
+        sorted
+            .iter()
+            .map(|s| printed_width(&avail_cell(m, s, 5, 0))),
     );
     let reward_w = fit(
         REWARD_WIDTH,
-        sorted.iter().map(|s| avail_cell(m, s, 9, 0).len()),
+        sorted
+            .iter()
+            .map(|s| printed_width(&avail_cell(m, s, 9, 0))),
     );
     let grown = (shards_w - SHARDS_WIDTH) + (reward_w - REWARD_WIDTH);
     let mut fw = content_width.saturating_sub(AVAIL_FIXED_WIDTH + grown);
@@ -608,7 +764,10 @@ fn avail_widths_fixed(m: &Model, content_width: usize, sorted: &[ShardRow]) -> (
         if col == 1 {
             continue;
         }
-        if m.avail_col_filters.get(&col).is_some_and(|cf| cf.is_active()) {
+        if m.avail_col_filters
+            .get(&col)
+            .is_some_and(|cf| cf.is_active())
+        {
             fw = fw.saturating_sub(1);
         }
     }
@@ -620,18 +779,25 @@ fn avail_widths_fixed(m: &Model, content_width: usize, sorted: &[ShardRow]) -> (
         PROVERS_WIDTH,
         RING_WIDTH,
         SIZE_WIDTH,
-        shards_w, MAT_WIDTH, LAG_WIDTH, STATE_WIDTH, reward_w,
+        shards_w,
+        MAT_WIDTH,
+        LAG_WIDTH,
+        STATE_WIDTH,
+        reward_w,
     ];
     for &col in &AVAIL_FILTERABLE_COLS {
         if col == 1 {
             continue;
         }
-        if m.avail_col_filters.get(&col).is_some_and(|cf| cf.is_active()) {
+        if m.avail_col_filters
+            .get(&col)
+            .is_some_and(|cf| cf.is_active())
+        {
             widths[col] += 1;
         }
     }
     if m.avail_sort_col >= 0 && (m.avail_sort_col as usize) < widths.len() {
-        widths[m.avail_sort_col as usize] += 2;
+        widths[m.avail_sort_col as usize] += 1;
     }
     (widths, fw)
 }
@@ -641,7 +807,10 @@ fn render_avail_panel(m: &mut Model, sorted: &[ShardRow], area: Rect) -> Vec<Lin
     let height = area.height as usize;
     if sorted.is_empty() {
         if !m.data_loaded {
-            return vec![Line::from(format!("  {} Loading available shards…", spinner(m)))];
+            return vec![Line::from(format!(
+                "  {} Loading available shards…",
+                spinner(m)
+            ))];
         }
         return vec![Line::from("  No available shards")];
     }
@@ -650,22 +819,38 @@ fn render_avail_panel(m: &mut Model, sorted: &[ShardRow], area: Rect) -> Vec<Lin
 
     let mut hdr_spans: Vec<Span> = Vec::new();
     for i in 0..AVAIL_COL_NAMES.len() {
-        let cell = format!("{:>w$}", avail_header(m, i), w = widths[i]);
-        let style = if m.sort_mode && !m.focus.is_alloc() && m.sort_highlight_col == i {
-            Style::new().bg(PRIMARY).fg(TEXT).add_modifier(Modifier::BOLD)
-        } else if m.avail_filter_mode
+        let hi_sort = m.sort_mode && !m.focus.is_alloc() && m.sort_highlight_col == i;
+        let hi_filter = m.avail_filter_mode
             && !m.filter_edit_active
             && !m.focus.is_alloc()
-            && filter_hi == i as i32
-        {
-            Style::new().bg(FILTER).fg(TEXT).add_modifier(Modifier::BOLD)
+            && filter_hi == i as i32;
+        let style = if hi_sort {
+            Style::new()
+                .bg(PRIMARY)
+                .fg(TEXT)
+                .add_modifier(Modifier::BOLD)
+        } else if hi_filter {
+            Style::new()
+                .bg(FILTER)
+                .fg(TEXT)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::new().add_modifier(Modifier::BOLD)
         };
+        let sorted = m.avail_sort_col == i as i32;
         if i > 0 {
             hdr_spans.push(Span::raw(" "));
         }
-        hdr_spans.push(Span::styled(cell, style));
+        // The available panel has no action columns; every value is a
+        // quantity, so every column stays right-justified.
+        hdr_spans.extend(header_spans(
+            &avail_header(m, i),
+            widths[i],
+            style,
+            sorted,
+            sorted && m.color_coding && !hi_sort && !hi_filter,
+            false,
+        ));
     }
     let mut lines = vec![Line::from(hdr_spans)];
 
@@ -688,6 +873,7 @@ fn render_avail_panel(m: &mut Model, sorted: &[ShardRow], area: Rect) -> Vec<Lin
             )));
         } else {
             // Non-selected: size uses human-readable storage; ring colored.
+
             let mut spans: Vec<Span> = Vec::new();
             for c in 0..widths.len() {
                 if c > 0 {
@@ -696,7 +882,13 @@ fn render_avail_panel(m: &mut Model, sorted: &[ShardRow], area: Rect) -> Vec<Lin
                 let cell = format!("{:>w$}", avail_cell(m, s, c, fw), w = widths[c]);
                 spans.push(match c {
                     3 if m.color_coding => Span::styled(cell, Style::new().fg(ring_color(s.ring))),
-                    8 if m.color_coding => Span::styled(cell, Style::new().fg(materialization_state_color(materialization_state(s.materialized_frame, s.latest_frame)))),
+                    6 | 7 | 8 if m.color_coding => {
+                        let color = materialization_state_color(materialization_state(
+                            s.materialized_frame,
+                            s.latest_frame,
+                        ));
+                        Span::styled(cell, Style::new().fg(color))
+                    }
                     _ => Span::raw(cell),
                 });
             }
@@ -784,7 +976,7 @@ fn help_line(m: &Model) -> Line<'static> {
     let filters_active = m.has_active_filters();
 
     // (key, desc, action-tag)
-    let entries: [(&str, &str, &str); 19] = [
+    let entries: [(&str, &str, &str); 20] = [
         ("tab", "switch", ""),
         ("↑/k", "up", ""),
         ("↓/j", "down", ""),
@@ -802,6 +994,7 @@ fn help_line(m: &Model) -> Line<'static> {
         ("f", "filter", "Filter"),
         ("C", "colors", "ColorCoding"),
         ("w", "widths", "ColumnSizing"),
+        ("e", "frames/epochs", "ThresholdUnit"),
         ("h", "help", ""),
         ("q", "quit", ""),
     ];
@@ -833,6 +1026,13 @@ fn help_line(m: &Model) -> Line<'static> {
                     Style::new().fg(HELP)
                 }
             }
+            "ThresholdUnit" => {
+                if m.threshold_unit == ThresholdUnit::Epochs {
+                    Style::new().fg(SUCCESS)
+                } else {
+                    Style::new().fg(HELP)
+                }
+            }
             "" => Style::new().fg(HELP),
             t if applicable.contains(t) => Style::new().fg(PRIMARY).add_modifier(Modifier::BOLD),
             _ => Style::new().fg(DIM),
@@ -844,9 +1044,15 @@ fn help_line(m: &Model) -> Line<'static> {
 
 fn render_filter_edit_lines(m: &Model) -> (Line<'static>, Line<'static>) {
     let col_name = if m.focus.is_alloc() {
-        ALLOC_COL_NAMES.get(m.filter_edit_col_idx).copied().unwrap_or("")
+        ALLOC_COL_NAMES
+            .get(m.filter_edit_col_idx)
+            .copied()
+            .unwrap_or("")
     } else {
-        AVAIL_COL_NAMES.get(m.filter_edit_col_idx).copied().unwrap_or("")
+        AVAIL_COL_NAMES
+            .get(m.filter_edit_col_idx)
+            .copied()
+            .unwrap_or("")
     };
     let kind = m.active_filter_col_kind(m.filter_edit_col_idx);
 
@@ -867,7 +1073,10 @@ fn render_filter_edit_lines(m: &Model) -> (Line<'static>, Line<'static>) {
                     Style::new().fg(FILTER).add_modifier(Modifier::BOLD),
                 ));
             } else {
-                spans.push(Span::styled(format!("  {checked} {v}"), Style::new().fg(HELP)));
+                spans.push(Span::styled(
+                    format!("  {checked} {v}"),
+                    Style::new().fg(HELP),
+                ));
             }
         }
         let status = Line::from(Span::styled(
@@ -886,37 +1095,84 @@ fn render_filter_edit_lines(m: &Model) -> (Line<'static>, Line<'static>) {
     } else {
         "[enter] apply  [esc] cancel"
     };
-    (actions, Line::from(Span::styled(hint, Style::new().fg(HELP))))
+    (
+        actions,
+        Line::from(Span::styled(hint, Style::new().fg(HELP))),
+    )
 }
 
 // ── Help screen ──────────────────────────────────────────────────────────
 
-fn render_help_screen(f: &mut Frame, m: &Model, area: Rect) {
-    let sec = |s: &str| Line::from(Span::styled(s.to_string(), Style::new().fg(PRIMARY).add_modifier(Modifier::BOLD)));
+fn render_help_screen(f: &mut Frame, m: &mut Model, area: Rect) {
+    let body = help_body();
+    m.help_lines = body.len();
+    let body_height = (area.height as usize).saturating_sub(1);
+    let max_offset = body.len().saturating_sub(body_height);
+    m.help_offset = m.help_offset.min(max_offset);
+
+    let title = if max_offset == 0 {
+        " Shard Manager — Help".to_string()
+    } else {
+        format!(
+            " Shard Manager — Help    ↑/↓ scroll  ({}–{} of {})",
+            m.help_offset + 1,
+            (m.help_offset + body_height).min(body.len()),
+            body.len()
+        )
+    };
+    let mut out = vec![Line::from(Span::styled(
+        format!("{:<width$}", title, width = area.width as usize),
+        Style::new()
+            .fg(TEXT)
+            .bg(PRIMARY)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    out.extend(body.into_iter().skip(m.help_offset).take(body_height));
+    f.render_widget(Paragraph::new(out), area);
+}
+
+/// Everything under the pinned title, in one place so a test can read it.
+/// A column or a key that never appears here is undocumented, and the help
+/// is the only surface that says what `Lag` or `re-confirm!` mean.
+fn help_body() -> Vec<Line<'static>> {
+    let sec = |s: &str| {
+        Line::from(Span::styled(
+            s.to_string(),
+            Style::new().fg(PRIMARY).add_modifier(Modifier::BOLD),
+        ))
+    };
     let kv = |k: &str, v: &str| {
         Line::from(vec![
-            Span::styled(format!("  {:<14}", k), Style::new().fg(TEXT).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                format!("  {:<16}", k),
+                Style::new().fg(TEXT).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(v.to_string(), Style::new().fg(HELP)),
         ])
     };
     let note = |s: &str| Line::from(Span::styled(format!("  {s}"), Style::new().fg(FILTER)));
 
-    let mut lines = vec![
-        Line::from(Span::styled(
-            " Shard Manager — Help",
-            Style::new().fg(TEXT).bg(PRIMARY).add_modifier(Modifier::BOLD),
-        )),
+    vec![
         Line::from(""),
         sec("Navigation"),
         kv("↑ / k", "Move cursor up"),
         kv("↓ / j", "Move cursor down"),
-        kv("Tab", "Switch between Allocations and Available Shards panels"),
+        kv(
+            "Tab",
+            "Switch between Allocations and Available Shards panels",
+        ),
         kv("Space", "Toggle selection on cursor row (advances cursor)"),
         kv("a", "Select all / deselect all rows in current panel"),
         Line::from(""),
         sec("Actions — Allocations panel"),
-        kv("l", "Leave  — request to leave an Active allocation (status 2)"),
-        kv("c", "Confirm — confirm a pending Join/Leave once the window opens"),
+        kv(
+            "l",
+            "Leave  — request to leave an Active allocation (status 2)",
+        ),
+        kv(
+            "c",
+            "Confirm — confirm a pending Join/Leave once the window opens",
+        ),
         kv("r", "Reject  — reject a pending Join/Leave"),
         kv("p", "Pause   — pause an Active allocation (status 2)"),
         kv("u", "Resume  — resume a Paused allocation (status 3)"),
@@ -927,41 +1183,88 @@ fn render_help_screen(f: &mut Frame, m: &Model, area: Rect) {
         kv("J", "Join    — open worker picker for selected shard(s)"),
         note("At least one free (unassigned) worker must exist to join."),
         Line::from(""),
+        sec("Worker picker  (opens on J)"),
+        kv("↑ / k, ↓ / j", "Move cursor between free workers"),
+        kv("Space", "Toggle a worker into the manual-management set"),
+        kv("enter / J", "Join the shard(s); selected workers are set to Manual"),
+        kv("esc", "Cancel the join"),
+        Line::from(""),
         sec("Sort mode  (press s)"),
+        kv("s", "Enter sort mode"),
         kv("← / →", "Move highlight to previous / next column"),
         kv("enter", "Confirm column, then choose sort order"),
         kv("a", "Ascending order"),
         kv("d", "Descending order"),
         kv("esc", "Cancel sort mode"),
+        note("The sorted column's header is underlined, with ↑ or ↓ for the order."),
         Line::from(""),
         sec("Filter mode  (press f)"),
-        kv("← / →", "Move highlight to previous / next filterable column"),
+        kv("f", "Enter filter mode"),
+        kv(
+            "← / →",
+            "Move highlight to previous / next filterable column",
+        ),
         kv("enter", "Open filter editor for highlighted column"),
-        kv("del", "Clear filter on highlighted column"),
+        kv("del / backspace", "Clear filter on highlighted column"),
         kv("x", "Disable all filters in current panel"),
         kv("esc", "Close filter mode"),
-        note("Filter editor: text columns accept a substring; numeric columns accept"),
-        note("an expression like \"> 47\", \"< 100\", or a comma list \"1,5,7\";"),
-        note("select columns toggle values with Space, confirm with Enter."),
+        note("An active filter marks its column header with *."),
+        Line::from(""),
+        sec("Filter editor  (enter, from filter mode)"),
+        kv("type", "Text columns take a substring; numeric columns take an"),
+        kv("", "expression like \"> 47\", \"< 100\", or a comma list \"1,5,7\""),
+        kv("backspace", "Delete the last character (Ctrl+H does the same)"),
+        kv("← / →", "Select columns: move between the available values"),
+        kv("Space", "Select columns: toggle the value under the cursor"),
+        kv("a", "Select columns: select all / deselect all values"),
+        kv("enter", "Apply the filter"),
+        kv("esc", "Cancel without changing the filter"),
+        Line::from(""),
+        sec("Columns"),
+        kv("Select", "[x] marks the row for a batch action (Space, or `a` for all)"),
+        kv("Filter", "Shard filter, in hex; shortened from the middle when narrow"),
+        kv("Provers", "Provers currently active on the shard"),
+        kv("Ring", "Prover ring the shard sits in; colour runs 0 green to 4+ red"),
+        kv("Size [MB]", "Shard size, in megabytes"),
+        kv("Shards", "Data shards the filter covers"),
+        kv("Mat", "Highest frame this shard has materialized locally"),
+        kv("Lag", "Frames behind the head: head − Mat; `-` when no head is known"),
+        kv("State", "Reading of Mat and Lag — Current: materialized up to the head;"),
+        kv("", "Lag: behind it; Unmat: nothing materialized; Unknown: no head"),
+        kv(
+            "Reward [Q/d]",
+            "Estimated whole QUIL per day; `<1` is a trickle, not nothing",
+        ),
+        kv("Worker", "Core the allocation is bound to; -1 means none is bound"),
+        kv("Status", "joining, active, paused, leaving, rejected, kicked;"),
+        kv("", "expiredJoin / expiredLeave: confirm window missed;"),
+        kv("", "re-confirm!: the allocation's epoch is stale but recoverable"),
+        kv("Mode", "Worker management — a: automatic, m: manual (toggle with M)"),
+        kv("Next Action", "What you can do now, and the threshold it applies from"),
+        kv(
+            "Default Action",
+            "What the network does if you do nothing, and when",
+        ),
+        note("Thresholds read f<frame> or e<epoch>; press e to switch. Q/d is whole"),
+        note("QUIL per day, MB is megabytes. Available Shards shows the same columns,"),
+        note("minus the ones that only exist once a shard is allocated to you."),
         Line::from(""),
         sec("General"),
         kv("R", "Force data refresh"),
-        kv("C", "Toggle color-coding of Ring, Status and Mode columns"),
+        kv(
+            "C",
+            "Toggle color-coding of Ring, Mat/Lag/State, Worker, Status and Mode",
+        ),
         kv("w", "Column widths: sized to content (default) or fixed"),
-        kv("h", "Toggle this help screen"),
+        kv(
+            "e",
+            "Show Next/Default Action thresholds as frames (f…) or epochs (e…)",
+        ),
+        kv("h", "Open this help screen (↑/↓ or PgUp/PgDn scroll; h or esc closes)"),
         kv("q / Ctrl+C", "Quit"),
         Line::from(""),
         Line::from(Span::styled("Press h to return", Style::new().fg(HELP))),
-    ];
-    // Header title fills width.
-    if let Some(first) = lines.first_mut() {
-        *first = Line::from(Span::styled(
-            format!("{:<width$}", " Shard Manager — Help", width = area.width as usize),
-            Style::new().fg(TEXT).bg(PRIMARY).add_modifier(Modifier::BOLD),
-        ));
-    }
-    let _ = m;
-    f.render_widget(Paragraph::new(lines), area);
+    ]
 }
 
 // ── Join worker picker ───────────────────────────────────────────────────
@@ -969,8 +1272,15 @@ fn render_help_screen(f: &mut Frame, m: &Model, area: Rect) {
 fn render_join_picker(f: &mut Frame, m: &mut Model, area: Rect) {
     let mut lines = vec![
         Line::from(Span::styled(
-            format!("{:<width$}", " Select workers to mark as manually managed", width = area.width as usize),
-            Style::new().fg(TEXT).bg(PRIMARY).add_modifier(Modifier::BOLD),
+            format!(
+                "{:<width$}",
+                " Select workers to mark as manually managed",
+                width = area.width as usize
+            ),
+            Style::new()
+                .fg(TEXT)
+                .bg(PRIMARY)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(format!(
@@ -995,10 +1305,17 @@ fn render_join_picker(f: &mut Frame, m: &mut Model, area: Rect) {
         } else {
             "[ ]"
         };
-        let cursor = if i == m.join_picker_cursor { "> " } else { "  " };
+        let cursor = if i == m.join_picker_cursor {
+            "> "
+        } else {
+            "  "
+        };
         let text = format!("{cursor}{marker} Worker {wid}");
         if i == m.join_picker_cursor {
-            lines.push(Line::from(Span::styled(text, Style::new().fg(TEXT).bg(PRIMARY))));
+            lines.push(Line::from(Span::styled(
+                text,
+                Style::new().fg(TEXT).bg(PRIMARY),
+            )));
         } else {
             lines.push(Line::from(text));
         }
@@ -1014,6 +1331,7 @@ fn render_join_picker(f: &mut Frame, m: &mut Model, area: Rect) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::node::prover::epoch::ActionHint;
 
     /// One allocations row. Only the fields that reach a cell are meaningful.
     fn row(
@@ -1040,8 +1358,8 @@ mod tests {
             join_frame: 0,
             leave_frame: 0,
             worker_id: worker,
-            next_action: next.to_string(),
-            default_action: dflt.to_string(),
+            next_action: ActionHint::text(next),
+            default_action: ActionHint::text(dflt),
             manually_managed: false,
             confirm_frame: 0,
             leave_confirm_frame: 0,
@@ -1081,12 +1399,15 @@ mod tests {
                 // Rendering is now independent of the cursor by construction;
                 // this pins the reward cell to the header's unit.
                 let cell = avail_cell(&m, s, c, 64);
-                assert!(!cell.contains("Q/f"), "column {c} repeats the header unit: {cell}");
+                assert!(
+                    !cell.contains("Q/f"),
+                    "column {c} repeats the header unit: {cell}"
+                );
             }
         }
         // Reward stops carrying its unit, so the column fits its header.
         let (w, _) = avail_col_widths(&m, 154, &rows);
-        assert_eq!(w[6], avail_header(&m, 6).len());
+        assert_eq!(w[6], printed_width(&avail_header(&m, 6)));
     }
 
     /// The table as reported: 15 joining allocations, sorted ascending on
@@ -1099,8 +1420,8 @@ mod tests {
                     57,
                     10_076_371,
                     i as i64,
-                    "confirmed",
-                    "active@e972",
+                    "(pause|leave)",
+                    "activate@f699840",
                 )
             })
             .collect()
@@ -1115,10 +1436,10 @@ mod tests {
 
     #[test]
     fn header_text_decorates_and_underscores() {
-        assert_eq!(header_text("Worker", 7, 7, true, false, false), "^|Worker");
-        assert_eq!(header_text("Worker", 7, 7, false, false, false), "v|Worker");
+        assert_eq!(header_text("Worker", 7, 7, true, false, false), "↑Worker");
+        assert_eq!(header_text("Worker", 7, 7, false, false, false), "↓Worker");
         assert_eq!(header_text("Ring", 3, 7, true, true, false), "Ring*");
-        assert_eq!(header_text("Ring", 3, 3, true, true, false), "^|Ring*");
+        assert_eq!(header_text("Ring", 3, 3, true, true, false), "↑Ring*");
         // Measured columns sit one space apart, so the spaces inside a name
         // become underscores to keep the pairs readable.
         assert_eq!(
@@ -1141,7 +1462,7 @@ mod tests {
             w,
             vec![
                 6,  // "Select"
-                35, // Filter — what the pane has left
+                32, // Filter — what the pane has left
                 7,  // "Provers"
                 4,  // "Ring"
                 9,  // "Size_[MB]"
@@ -1149,15 +1470,15 @@ mod tests {
                 3,  // "Mat"
                 3,  // "Lag"
                 7,  // "joining", wider than "State"
-                12, // "Reward_[Q/f]"
-                8,  // "^|Worker", including the active sort indicator
+                12, // "Reward_[Q/d]"
+                7,  // "↑Worker", including the active sort arrow
                 7,  // "joining", wider than "Status"
                 4,  // "Mode"
-                11, // "Next_Action", wider than "confirmed"
-                14, // "Default_Action", wider than "active@e972"
+                13, // "(pause|leave)", wider than "Next_Action"
+                16, // "activate@f699840", wider than "Default_Action"
             ]
         );
-        assert_eq!(fw, 35);
+        assert_eq!(fw, 32);
         // 15 columns + 14 separators + 2 borders fill the pane exactly.
         assert_eq!(w.iter().sum::<usize>() + 14 + 2, 154);
     }
@@ -1165,10 +1486,10 @@ mod tests {
     #[test]
     fn fixed_sizing_reproduces_the_historical_layout() {
         let (w, fw) = alloc_col_widths(&fixed(), 154, &joining_table());
-        assert_eq!(w, vec![6, 12, 7, 5, 10, 8, 9, 6, 8, 14, 9, 12, 4, 30, 16]);
+        assert_eq!(w, vec![6, 12, 7, 5, 10, 8, 9, 6, 8, 12, 8, 12, 4, 26, 18]);
         assert_eq!(fw, 12);
-        assert_eq!(w.iter().sum::<usize>() + 14, 170);
-        // 30 columns of Next Action for a 9-column value in the fixed layout.
+        assert_eq!(w.iter().sum::<usize>() + 14, 165);
+        // 26 columns of Next Action for a 13-column value in the fixed layout.
         assert_eq!(w[13], NEXT_ACTION_WIDTH);
     }
 
@@ -1181,9 +1502,9 @@ mod tests {
                 for a in &rows {
                     let cell = alloc_cell(&m, a, c, fw);
                     assert!(
-                        cell.len() <= *width,
+                        printed_width(&cell) <= *width,
                         "column {c} is {width} wide but a cell needs {}",
-                        cell.len()
+                        printed_width(&cell)
                     );
                 }
             }
@@ -1195,13 +1516,13 @@ mod tests {
         let m = Model::new();
         let mut rows = joining_table();
         let (before, before_fw) = alloc_col_widths(&m, 154, &rows);
-        rows[3].next_action = "reject | confirm now".to_string();
+        rows[3].next_action = ActionHint::text("(reject|confirm)");
         let (after, after_fw) = alloc_col_widths(&m, 154, &rows);
 
-        assert_eq!(before[13], 11);
-        assert_eq!(after[13], 20);
+        assert_eq!(before[13], 13);
+        assert_eq!(after[13], 16);
         // Filter gives back exactly what Next Action took; the row still fits.
-        assert_eq!(before_fw - after_fw, 9);
+        assert_eq!(before_fw - after_fw, 3);
         assert_eq!(after.iter().sum::<usize>() + 14 + 2, 154);
     }
 
@@ -1211,12 +1532,164 @@ mod tests {
         let rows = joining_table();
         // Wide pane: Filter stops at the longest hex rather than padding on.
         assert_eq!(alloc_col_widths(&m, 300, &rows).1, 64);
-        assert_eq!(alloc_col_widths(&m, 167, &rows).1, 48);
+        assert_eq!(alloc_col_widths(&m, 167, &rows).1, 45);
         // Narrower: Filter absorbs the shortfall…
-        assert_eq!(alloc_col_widths(&m, 154, &rows).1, 35);
-        assert_eq!(alloc_col_widths(&m, 118, &rows).1, 12);
+        assert_eq!(alloc_col_widths(&m, 154, &rows).1, 32);
+        assert_eq!(alloc_col_widths(&m, 121, &rows).1, 12);
         // …down to the floor, past which the row is clipped rather than shrunk.
-        assert_eq!(alloc_col_widths(&m, 115, &rows).1, MIN_FILTER_WIDTH);
+        assert_eq!(alloc_col_widths(&m, 118, &rows).1, MIN_FILTER_WIDTH);
         assert_eq!(alloc_col_widths(&m, 40, &rows).1, MIN_FILTER_WIDTH);
+    }
+
+    fn joined(spans: &[Span<'static>]) -> String {
+        spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    /// The arrow already said which column sorts, but only to someone reading
+    /// the header row character by character. The underline is the part that
+    /// works without colour and without reading.
+    #[test]
+    fn the_sorted_column_is_marked_without_colour() {
+        let base = Style::new().add_modifier(Modifier::BOLD);
+        let spans = header_spans("↑Worker", 9, base, true, false, false);
+        assert_eq!(joined(&spans), "  ↑Worker");
+        assert!(spans
+            .iter()
+            .all(|s| s.style.add_modifier.contains(Modifier::UNDERLINED)));
+        assert!(spans.iter().all(|s| s.style.fg.is_none()));
+        // An unsorted column is left exactly as it was.
+        let plain = header_spans("Worker", 9, base, false, false, false);
+        assert_eq!(joined(&plain), "   Worker");
+        assert!(plain
+            .iter()
+            .all(|s| !s.style.add_modifier.contains(Modifier::UNDERLINED)));
+    }
+
+    /// Tinting the whole header would compete with the column's values; only
+    /// the one character that carries the sort direction takes the colour.
+    #[test]
+    fn only_the_arrow_carries_the_sort_colour() {
+        let spans = header_spans(
+            "↓Reward [Q/d]",
+            14,
+            Style::new().add_modifier(Modifier::BOLD),
+            true,
+            true,
+            false,
+        );
+        assert_eq!(joined(&spans), " ↓Reward [Q/d]");
+        let tinted: Vec<&Span<'static>> =
+            spans.iter().filter(|s| s.style.fg == Some(SORT)).collect();
+        assert_eq!(tinted.len(), 1);
+        assert_eq!(tinted[0].content.as_ref(), "↓");
+    }
+
+    /// The cell is drawn as several spans, so the padding has to keep the
+    /// style; a bare `Span::raw` pad would punch a hole in the sort-mode
+    /// highlight, on the side the column aligns away from.
+    #[test]
+    fn padding_shares_the_highlight_style() {
+        let base = Style::new()
+            .bg(PRIMARY)
+            .fg(TEXT)
+            .add_modifier(Modifier::BOLD);
+        for left in [false, true] {
+            let spans = header_spans("Mode", 8, base, true, false, left);
+            assert!(spans.iter().all(|s| s.style.bg == Some(PRIMARY)));
+            assert_eq!(joined(&spans).trim(), "Mode");
+        }
+    }
+
+    /// Next Action is the one column whose values do not all end the same
+    /// way, so it is the one column that cannot align on its tail. Default
+    /// Action stays right: its thresholds are the point of the column, and
+    /// they only read as a list when they line up.
+    #[test]
+    fn only_next_action_aligns_left() {
+        assert!(alloc_left_aligned(13));
+        for c in (0..ALLOC_COL_NAMES.len()).filter(|c| *c != 13) {
+            assert!(
+                !alloc_left_aligned(c),
+                "column {c} should stay right-aligned"
+            );
+        }
+        assert_eq!(
+            pad_cell("(pause|leave)", 22, true),
+            "(pause|leave)         "
+        );
+        assert_eq!(pad_cell("renew@f804960", 16, false), "   renew@f804960");
+        assert_eq!(pad_cell("expire@f805680", 16, false), "  expire@f805680");
+    }
+
+    /// Colouring every bound worker green would tint most of the table and
+    /// leave the one row that needs attention no louder than the rest.
+    #[test]
+    fn an_unbound_worker_is_the_only_id_worth_colouring() {
+        assert_eq!(worker_color(-1), Some(ERROR));
+        assert_eq!(worker_color(0), None);
+        assert_eq!(worker_color(57), None);
+    }
+
+    fn help_text() -> String {
+        help_body()
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|sp| sp.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The help is the only place that says what `Lag`, `Mode` or
+    /// `re-confirm!` mean. A column added without a line here ships
+    /// undocumented, and nothing else would catch it.
+    #[test]
+    fn every_column_has_a_help_entry() {
+        let text = help_text();
+        for name in ALLOC_COL_NAMES.iter().chain(AVAIL_COL_NAMES.iter()) {
+            assert!(text.contains(*name), "column `{name}` has no help entry");
+        }
+    }
+
+    /// The documented keys: the left-hand column of every `kv` line. Matching
+    /// on the whole text would pass on any single letter appearing anywhere in
+    /// a sentence, which is how `d` and `x` went undocumented while a naive
+    /// `contains` said otherwise.
+    fn documented_keys() -> Vec<String> {
+        help_body()
+            .iter()
+            .filter(|l| l.spans.len() == 2)
+            .map(|l| l.spans[0].content.trim().to_string())
+            .collect()
+    }
+
+    /// Listed by hand against `handle_normal_key` and its mode handlers: a
+    /// binding that exists and is undocumented is exactly what this should
+    /// force someone to reconcile.
+    #[test]
+    fn every_key_has_a_help_entry() {
+        let keys = documented_keys();
+        for key in [
+            "l", "c", "r", "p", "u", "M", "J", "s", "f", "R", "C", "w", "e", "h", "a", "x", "d",
+            "Tab", "Space", "enter", "esc", "q / Ctrl+C",
+        ] {
+            assert!(
+                keys.iter().any(|k| k == key),
+                "key `{key}` has no help entry"
+            );
+        }
+    }
+
+    /// The help outgrew a terminal the moment it documented everything, so
+    /// it scrolls; the title is pinned and never counted as body.
+    #[test]
+    fn the_help_is_longer_than_a_terminal_and_so_it_scrolls() {
+        assert!(
+            help_body().len() > 50,
+            "help fits on one screen; the scroll path is now untested"
+        );
     }
 }

--- a/crates/quil-client/src/commands/node/prover/mod.rs
+++ b/crates/quil-client/src/commands/node/prover/mod.rs
@@ -232,25 +232,25 @@ pub(crate) fn format_mb(v: &BigInt) -> String {
     }
 }
 
-/// `formatQUIL` — reward units (1 QUIL = 10^8 units) → 8-decimal string.
-/// NOTE: distinct from the token module's 8e9/12-decimal balance format.
-pub(crate) fn format_quil_reward(raw: &BigInt) -> String {
-    if raw.sign() == Sign::NoSign {
-        return "0.00000000".to_string();
-    }
-    let divisor = BigInt::from(100_000_000u64); // 10^8
-    let whole = raw / &divisor;
-    let frac = raw % &divisor;
-    // frac fits in i64; pad to 8 digits.
-    format!("{whole}.{:0>8}", frac.to_string())
-}
-
 /// `framesPerDay` — frames in 24h at a 10s target frame time.
 const FRAMES_PER_DAY: u64 = 24 * 60 * 60 / 10; // 8640
 
-/// `formatQUILDaily` — per-frame reward → estimated 24h total.
-pub(crate) fn format_quil_daily(per_frame: &BigInt) -> String {
-    format_quil_reward(&(per_frame * BigInt::from(FRAMES_PER_DAY)))
+/// `formatQUILDaily` (per-frame reward → estimated 24h total), rounded to
+/// whole QUIL. Reward units are 1 QUIL = 10^8, and at a fraction of a cent
+/// per QUIL the eight decimals of a raw amount carry no decision value; the
+/// spread that does matter between shards survives rounding. A non-zero
+/// amount below the rounding threshold prints `<1` so it stays
+/// distinguishable from nothing at all.
+pub(crate) fn format_quil_daily_round(per_frame: &BigInt) -> String {
+    let raw = per_frame * BigInt::from(FRAMES_PER_DAY);
+    if raw.sign() != Sign::Plus {
+        return "0".to_string();
+    }
+    let whole = (raw + BigInt::from(50_000_000u64)) / BigInt::from(100_000_000u64);
+    if whole.sign() != Sign::Plus {
+        return "<1".to_string();
+    }
+    whole.to_string()
 }
 
 #[cfg(test)]
@@ -276,10 +276,21 @@ mod tests {
     }
 
     #[test]
-    fn format_quil_reward_8dp() {
-        assert_eq!(format_quil_reward(&BigInt::from(0)), "0.00000000");
-        assert_eq!(format_quil_reward(&BigInt::from(100_000_000u64)), "1.00000000");
-        assert_eq!(format_quil_reward(&BigInt::from(150_000_000u64)), "1.50000000");
-        assert_eq!(format_quil_reward(&BigInt::from(1u64)), "0.00000001");
+    fn format_quil_daily_round_separates_a_trickle_from_nothing() {
+        // `per_frame` is scaled by FRAMES_PER_DAY, so 1 unit/frame is
+        // 8640 units/day = 0.0000864 QUIL/day — a trickle, but not zero.
+        assert_eq!(format_quil_daily_round(&BigInt::from(0)), "0");
+        assert_eq!(format_quil_daily_round(&BigInt::from(1u64)), "<1");
+        // Exactly 0.5 QUIL/day rounds up; anything under it reads `<1`.
+        let half = BigInt::from(50_000_000u64 / FRAMES_PER_DAY); // 5787 -> 0.4999…
+        assert_eq!(format_quil_daily_round(&half), "<1");
+        assert_eq!(format_quil_daily_round(&(half + BigInt::from(1))), "1");
+        // The reported total: 269.91550080 QUIL/day.
+        assert_eq!(format_quil_daily_round(&BigInt::from(3_124_022u64)), "270");
+        // Per-shard rates observed on a live node collapse to a handful of
+        // tiers, and the ~15x spread that drives a join decision survives.
+        assert_eq!(format_quil_daily_round(&BigInt::from(4_498u64)), "<1");
+        assert_eq!(format_quil_daily_round(&BigInt::from(67_900u64)), "6");
+        assert_eq!(format_quil_daily_round(&BigInt::from(268_000u64)), "23");
     }
 }

--- a/crates/quil-client/src/commands/node/prover/shardinfo.rs
+++ b/crates/quil-client/src/commands/node/prover/shardinfo.rs
@@ -6,7 +6,7 @@ use num_bigint::{BigInt, Sign};
 
 use quil_types::proto::node::GetShardInfoRequest;
 
-use super::{format_quil_reward, format_storage, worker_by_filter, ProverCtx};
+use super::{format_quil_daily_round, format_storage, worker_by_filter, ProverCtx};
 
 pub async fn run(pc: &ProverCtx) -> anyhow::Result<()> {
     let mut client = pc.connect().await?;
@@ -43,13 +43,13 @@ pub async fn run(pc: &ProverCtx) -> anyhow::Result<()> {
         let shard_size_u64 = u64::try_from(shard_size).unwrap_or(u64::MAX);
 
         println!(
-            "  Filter: {}  Size: {:<10} Shards: {:<6} Provers: {:<4} Ring: {}  Reward: ~{} QUIL/frame{}",
+            "  Filter: {}  Size: {:<10} Shards: {:<6} Provers: {:<4} Ring: {}  Reward: {:<3} Q/d{}",
             filter_hex,
             format_storage(shard_size_u64),
             shard.data_shards,
             shard.active_provers,
             shard.ring,
-            format_quil_reward(&reward),
+            format_quil_daily_round(&reward),
             suffix
         );
     }

--- a/crates/quil-client/src/commands/node/prover/shards.rs
+++ b/crates/quil-client/src/commands/node/prover/shards.rs
@@ -6,7 +6,7 @@ use num_bigint::{BigInt, Sign};
 
 use quil_types::proto::node::GetShardInfoRequest;
 
-use super::{format_quil_daily, format_quil_reward, format_storage, worker_by_filter, ProverCtx};
+use super::{format_quil_daily_round, format_storage, worker_by_filter, ProverCtx};
 
 pub async fn run(pc: &ProverCtx) -> anyhow::Result<()> {
     let mut client = pc.connect().await?;
@@ -38,20 +38,19 @@ pub async fn run(pc: &ProverCtx) -> anyhow::Result<()> {
         total += &reward;
 
         println!(
-            "  Filter: {}  Shards: {:<6} Provers: {:<4} Ring: {}  Reward: ~{} QUIL/frame{}",
+            "  Filter: {}  Shards: {:<6} Provers: {:<4} Ring: {}  Reward: {:<3} Q/d{}",
             filter_hex,
             shard.data_shards,
             shard.active_provers,
             shard.ring,
-            format_quil_reward(&reward),
+            format_quil_daily_round(&reward),
             worker_str
         );
     }
 
     println!(
-        "\nTotal estimated: ~{} QUIL/frame (~{} QUIL/day)",
-        format_quil_reward(&total),
-        format_quil_daily(&total)
+        "\nTotal estimated: {} Q/d",
+        format_quil_daily_round(&total)
     );
     println!(
         "Difficulty: {}  Frame: {}",

--- a/crates/quil-client/src/commands/node/prover/status.rs
+++ b/crates/quil-client/src/commands/node/prover/status.rs
@@ -7,8 +7,8 @@ use num_bigint::{BigInt, Sign};
 use quil_types::proto::node::{GetNodeInfoRequest, GetWorkerInfoRequest, ShardAllocationInfo};
 
 use super::epoch::{
-    alloc_confirm_window, compute_effective_status, epoch_for_frame, epoch_len, AllocationTiming,
-    EffectiveStatus,
+    action_hints, compute_effective_status, epoch_for_frame, epoch_len, AllocationTiming,
+    ThresholdUnit,
 };
 use super::{format_storage, worker_by_filter, ProverCtx};
 
@@ -91,21 +91,14 @@ pub async fn run(pc: &ProverCtx) -> anyhow::Result<()> {
             eff.label()
         );
 
-        if let Some(w) = alloc_confirm_window(&t, epoch_length) {
+        // Same vocabulary as the `manage` TUI's Next/Default Action columns.
+        let (next, default) = action_hints(&t, eff, epoch_length, current_frame, next_boundary);
+        if !next.is_empty() || !default.is_empty() {
+            let unit = ThresholdUnit::Frames;
             println!(
-                "      Action: {} | {}",
-                w.label("Confirm", current_frame, epoch_length),
-                w.label("Reject", current_frame, epoch_length)
-            );
-        } else if eff == EffectiveStatus::Active && !alloc.filter.is_empty() {
-            println!(
-                "      Re-confirm through epoch {} (renew before frame {})",
-                alloc.epoch, next_boundary
-            );
-        } else if eff == EffectiveStatus::ExpiredEpoch {
-            println!(
-                "      MISSED re-confirm (registered epoch {} < current {}) — confirm now to restore",
-                alloc.epoch, cur_epoch
+                "      Next Action: {}  Default Action: {}",
+                next.render(unit, epoch_length),
+                default.render(unit, epoch_length)
             );
         }
 


### PR DESCRIPTION
The shard manager repeated `QUIL/day` five times in one title and printed eight decimals of a token worth a fraction of a cent, while its two action columns mixed frames with epochs and put a bare threshold under a header promising an action.

Rewards are now whole `Q/d` with the unit in the header; `<1` keeps a trickle distinguishable from nothing. Checked against a live node: 91 shards collapse to nine tiers, so the ~15x spread that drives a join decision survives rounding, and sorting still uses full precision. The unit is spelled the same way in `prover shards` and `prover shardinfo`.

Both action columns share one grammar — lowercase verbs matching the keys that trigger them, grouped when they share a threshold — and Default Action names what the network does unprompted rather than repeating the Status column. `e` toggles both between `@f<frame>` and `@e<epoch>` without a refetch.

Next Action is the one column laid out flush left: it is the only one whose values do not all carry a threshold, so a tail-aligned column stops looking like a column.

The sorted column's header is underlined — free in monochrome — and in colour mode only the direction arrow takes a colour, distinct from every status palette, so the mark reads as layout rather than as a value. Mat, Lag and State are three readings of one fact and share one colour; a worker id is coloured only when it is `-1`.

`h` opens a help screen that is now the only place this vocabulary is defined: every column, every key, both modal editors and the worker picker. It outgrew a terminal, so it scrolls under a pinned title.

**Base:** `4eaf1f79`
