### PR TITLE
fix(engine): rank shard leaves by score instead of by worker binding

### DIFF
--- a/crates/quil-engine/src/provers/lifecycle.rs
+++ b/crates/quil-engine/src/provers/lifecycle.rs
@@ -207,6 +207,46 @@ impl std::fmt::Debug for LifecycleAction {
     }
 }
 
+/// Allocations this prover holds on-chain that NOTHING is working — the
+/// "Leave regardless of score" set.
+///
+/// Candidates are `active` UNION `expired_epoch`. Including `expired_epoch` is
+/// what makes the sweep terminating rather than one-shot: being orphaned is
+/// precisely what makes an allocation expire, since no worker means no proofs
+/// and so a missed per-epoch re-confirm at the next boundary, after which the
+/// allocation leaves `active`. Sweeping `active` alone therefore gave an orphan
+/// a single epoch of eligibility and no way back, so an orphan that survived one
+/// boundary became permanently unsheddable. Observed in the wild as a node
+/// holding 35 allocations against 15 workers, the 20 unbound ones all reading
+/// `re-confirm!`, with no Leave ever proposed.
+///
+/// `expired_epoch` deliberately does NOT join `active` itself — that set is
+/// coverage accounting and an unconfirmed allocation genuinely does not count.
+/// This widens only who may be SHED.
+///
+/// Excluded: filters a worker is bound to (including in-flight joins, whose
+/// `worker.filter` is set at submit time), operator-pinned filters, and filters
+/// already mid-Leave.
+pub(crate) fn orphaned_allocation_filters(
+    active_filters: &[Vec<u8>],
+    expired_epoch_filters: &[Vec<u8>],
+    bound_filters: &std::collections::HashSet<Vec<u8>>,
+    manually_managed_filters: &std::collections::HashSet<Vec<u8>>,
+    pending_leave_filters: &std::collections::HashSet<Vec<u8>>,
+) -> Vec<Vec<u8>> {
+    let mut seen: std::collections::HashSet<&[u8]> = std::collections::HashSet::new();
+    active_filters
+        .iter()
+        .chain(expired_epoch_filters.iter())
+        .filter(|f| seen.insert(f.as_slice()))
+        .filter(|f| !bound_filters.contains(*f))
+        .filter(|f| !manually_managed_filters.contains(*f))
+        .filter(|f| !pending_leave_filters.contains(*f))
+        .cloned()
+        .collect()
+}
+
+
 /// Allocations partitioned by their effective status at a given
 /// frame. Lifecycle's `evaluate` collects these once and dispatches
 /// each downstream subroutine against the appropriate slice. Pulling
@@ -1095,7 +1135,12 @@ impl ProverLifecycle {
         let active_filters = buckets.active;
         let leaving_filters = buckets.leaving;
         let all_our_filters = buckets.all_ours;
+        // Cloned because the re-confirm path below consumes the original and
+        // the orphan-leave sweep needs it again: an ExpiredEpoch allocation is
+        // still on-chain Active, so it is a valid Leave target when nothing is
+        // working it.
         let expired_epoch_filters = buckets.expired_epoch;
+        let expired_epoch_for_orphan_sweep = expired_epoch_filters.clone();
 
         // Build separate descriptor views.
         //
@@ -1674,10 +1719,14 @@ impl ProverLifecycle {
         // proposing swap leaves against a phantom halt-risk shard for
         // hours (2026-06-16). Halt-risk swaps are still wanted — but only
         // off a trustworthy coverage view, i.e. when not halted.
+        // `expired_epoch` counts toward "we hold something worth evaluating"
+        // alongside `active`: a prover whose every allocation went ExpiredEpoch
+        // (all of them orphaned, e.g. after losing its workers) would otherwise
+        // skip the leave sweep entirely and never shed anything.
         if shard_info_ready
             && can_propose
             && !join_proposed_this_cycle
-            && !active_filters.is_empty()
+            && !(active_filters.is_empty() && expired_epoch_for_orphan_sweep.is_empty())
             && !self.halt_state.any_halted()
         {
             let manually_managed_filters: std::collections::HashSet<Vec<u8>> = workers
@@ -1712,19 +1761,35 @@ impl ProverLifecycle {
                 .cloned()
                 .collect();
 
-            // Orphan filters: Active allocations with no worker bound.
+            // Orphan filters: on-chain Active allocations with no worker bound.
             // Always propose leave regardless of shard score — there's
             // no useful work to retain. Fixes the "extra allocation
             // from earlier issues, shows as -1 in TUI" case where the
             // allocation lingers on a healthy shard and plan_leaves /
             // surplus-leave can't (or won't) pick it.
-            let orphan_filters: Vec<Vec<u8>> = active_filters
-                .iter()
-                .filter(|f| !bound_filters.contains(*f))
-                .filter(|f| !manually_managed_filters.contains(*f))
-                .filter(|f| !pending_leave_filters.contains(*f))
-                .cloned()
-                .collect();
+            //
+            // ExpiredEpoch allocations MUST be candidates here, not just
+            // `active` ones. Being orphaned is precisely what makes an
+            // allocation expire: no worker means no proofs, so it misses the
+            // per-epoch re-confirm at the next boundary and drops out of
+            // `active`. Sweeping only `active` therefore gave the orphan path a
+            // one-epoch window and no way back — an orphan that survived a
+            // single boundary became permanently unsheddable, which is how a
+            // node ends up holding far more allocations than it has workers with
+            // no automatic way out. Observed in the wild: 35 allocations against
+            // 15 workers, the 20 unbound ones all reading `re-confirm!`, and
+            // zero Leave proposals for as long as they stayed that way.
+            //
+            // They stay OUT of `active` itself — that set is coverage
+            // accounting, and an unconfirmed allocation genuinely does not
+            // count. This only widens who may be shed.
+            let orphan_filters = orphaned_allocation_filters(
+                &active_filters,
+                &expired_epoch_for_orphan_sweep,
+                &bound_filters,
+                &manually_managed_filters,
+                &pending_leave_filters,
+            );
 
             // §6.1 Option-A: SPLIT-PARENT filters — an Active filter that has been
             // SPLIT, i.e. some registered shard is a strict bit-path DESCENDANT of
@@ -4527,5 +4592,138 @@ mod halt_risk_descriptor_tests {
         );
         assert_eq!(descriptors.len(), 1);
         assert_eq!(descriptors[0].filter, filter_real);
+    }
+}
+
+#[cfg(test)]
+mod orphan_leave_tests {
+    use super::*;
+    use quil_types::consensus::{EffectiveStatus, ProverAllocationInfo, ProverStatus};
+
+    fn set(filters: &[&[u8]]) -> std::collections::HashSet<Vec<u8>> {
+        filters.iter().map(|f| f.to_vec()).collect()
+    }
+
+    fn none() -> std::collections::HashSet<Vec<u8>> {
+        std::collections::HashSet::new()
+    }
+
+    /// An Active allocation held for `epoch`, i.e. one that reads ExpiredEpoch
+    /// once the chain passes that epoch.
+    fn active_alloc(filter: u8, epoch: u64) -> ProverAllocationInfo {
+        ProverAllocationInfo {
+            status: ProverStatus::Active,
+            confirmation_filter: vec![filter],
+            rejection_filter: Vec::new(),
+            join_frame_number: 0,
+            leave_frame_number: 0,
+            pause_frame_number: 0,
+            resume_frame_number: 0,
+            kick_frame_number: 0,
+            join_confirm_frame_number: 0,
+            join_reject_frame_number: 0,
+            leave_confirm_frame_number: 0,
+            leave_reject_frame_number: 0,
+            last_active_frame_number: 0,
+            epoch,
+            ring: 0,
+            vertex_address: Vec::new(),
+        }
+    }
+
+    /// THE BUG THIS GUARDS. An orphan's own orphanhood is what expires it: no
+    /// worker means no proofs, so it misses the per-epoch re-confirm and leaves
+    /// the `active` bucket. Sweeping `active` alone gave the orphan sweep a
+    /// single epoch of reach, after which the allocation was stuck forever —
+    /// the state behind "35 allocations, 15 workers, 20 reading `re-confirm!`,
+    /// no Leave ever proposed".
+    #[test]
+    fn an_orphan_that_outlived_its_epoch_is_still_proposed_for_leave() {
+        let bound = vec![0x01u8];
+        let orphan = vec![0x02u8];
+
+        // Both allocations registered for epoch 5; the chain is now in epoch 6.
+        let allocs = vec![active_alloc(0x01, 5), active_alloc(0x02, 5)];
+        let frame = 6 * quil_types::consensus::EPOCH_LENGTH_FRAMES;
+        let buckets = AllocationBuckets::from_allocations(&allocs, frame);
+
+        // Precondition: expiry has emptied `active`, which is exactly why the
+        // old `active`-only sweep saw nothing to shed.
+        assert!(
+            buckets.active.is_empty(),
+            "an allocation past its registered epoch must not count for coverage",
+        );
+        assert_eq!(buckets.expired_epoch.len(), 2);
+
+        let orphans = orphaned_allocation_filters(
+            &buckets.active,
+            &buckets.expired_epoch,
+            &set(&[&bound]),
+            &none(),
+            &none(),
+        );
+        assert_eq!(orphans, vec![orphan], "only the unbound one is shed");
+    }
+
+    /// The sweep must not shed what is being worked. An ExpiredEpoch allocation
+    /// WITH a worker is recoverable by re-confirming, so it is not an orphan.
+    #[test]
+    fn an_expired_allocation_with_a_worker_is_not_an_orphan() {
+        let filter = vec![0x07u8];
+        let orphans = orphaned_allocation_filters(
+            &[],
+            &[filter.clone()],
+            &set(&[&filter]),
+            &none(),
+            &none(),
+        );
+        assert!(orphans.is_empty());
+    }
+
+    /// Operator pins and in-flight Leaves still win, on the expired path as
+    /// much as the active one — otherwise widening the sweep would start
+    /// re-publishing Leaves for allocations already on their way out.
+    #[test]
+    fn pinned_and_already_leaving_expired_allocations_are_left_alone() {
+        let pinned = vec![0x03u8];
+        let leaving = vec![0x04u8];
+        let shed = vec![0x05u8];
+        let expired = vec![pinned.clone(), leaving.clone(), shed.clone()];
+
+        let orphans = orphaned_allocation_filters(
+            &[],
+            &expired,
+            &none(),
+            &set(&[&pinned]),
+            &set(&[&leaving]),
+        );
+        assert_eq!(orphans, vec![shed]);
+    }
+
+    /// An allocation can be in both buckets across a boundary; it must be
+    /// proposed once, not twice — a duplicated filter would inflate the
+    /// per-cycle proposal budget and the orphan count in the log line.
+    #[test]
+    fn a_filter_in_both_buckets_is_proposed_once() {
+        let f = vec![0x09u8];
+        let orphans = orphaned_allocation_filters(
+            &[f.clone()],
+            &[f.clone()],
+            &none(),
+            &none(),
+            &none(),
+        );
+        assert_eq!(orphans, vec![f]);
+    }
+
+    /// Sanity on the status mapping the sweep depends on: an unbound
+    /// allocation stays on-chain Active, so a Leave is a valid thing to
+    /// propose for it. It is only the DERIVED status that reads expired.
+    #[test]
+    fn an_expired_allocation_is_still_on_chain_active() {
+        let a = active_alloc(0x01, 5);
+        let frame = 6 * quil_types::consensus::EPOCH_LENGTH_FRAMES;
+        assert_eq!(a.effective_status(frame), EffectiveStatus::ExpiredEpoch);
+        assert_eq!(a.status, ProverStatus::Active);
     }
 }

--- a/crates/quil-engine/src/provers/lifecycle.rs
+++ b/crates/quil-engine/src/provers/lifecycle.rs
@@ -943,63 +943,93 @@ impl ProverLifecycle {
         }
         let surplus = total_active_count - total_capacity;
 
-        // Orphan active filters (no worker bound, not operator-pinned)
-        // are always the right answer to shed capacity-pressure: no
-        // worker does the work, so leaving them costs nothing. Pick
-        // them first; only fall back to lowest-scoring auto-bound when
-        // surplus exceeds the orphan count. This protects healthy
-        // bound filters from being evicted ahead of a stale orphan.
-        let mut picks: Vec<Vec<u8>> = active_filters
-            .iter()
-            .filter(|f| !bound_filters.contains(*f))
-            .filter(|f| !mm_filters.contains(*f))
-            .take(surplus)
-            .cloned()
-            .collect();
-
-        if picks.len() < surplus {
-            // Build the exclusion set: manually-managed pins + any
-            // shard whose post-leave Active count would land at or
-            // below the halt-risk threshold (`active_count <=
-            // HALT_RISK_PROVER_COUNT + 1`, matching `plan_leaves` and
-            // `decide_leaves`). Shedding a shard already at the
-            // threshold OR one our departure would push into it
-            // would immediately worsen the network's exposure.
-            // Operators dealing with chronic capacity pressure
-            // should reduce worker count or add manual pins, not
-            // auto-shed halt-risk-adjacent shards.
-            let mut excluded = mm_filters.clone();
-            for d in allocated_descriptors {
-                if d.size > 0 && d.active_count <= proposer::HALT_RISK_PROVER_COUNT + 1 {
-                    excluded.insert(d.filter.clone());
-                }
-            }
-            let ranked = proposer::rank_allocated_by_score_ascending(
-                allocated_descriptors,
-                difficulty,
-                world_bytes,
-                self.units,
-                self.strategy,
-                &excluded,
-            );
-            // Lowest-scoring `surplus - orphan_count` auto-bound. A
-            // filter that's `Active` but absent from `allocated_descriptors`
-            // is, in practice, a size-0 shard (build_decide_descriptors
-            // skipped it). Mirroring Go's `worker_allocator.go:821-824` —
-            // where `if size == 0 { continue }` lands BEFORE
-            // `leaveProposalCandidates = append(...)` — we deliberately
-            // do NOT pick those here. The empty-allocated path in the
-            // main ProposeLeave block surfaces them.
-            for (f, _) in ranked {
-                if picks.len() == surplus {
-                    break;
-                }
-                if picks.contains(&f) {
-                    continue;
-                }
-                picks.push(f);
+        // Shed the worst-scoring allocations, bound or not.
+        //
+        // This used to shed orphans (Active, no worker bound) first and
+        // score-blind, on the reasoning that "no worker does the work,
+        // so leaving them costs nothing." It costs the difference in
+        // score. Which allocations hold a worker is decided by bind
+        // order in the allocator, not by value: a crashed worker, a
+        // reduced core count, or a join batch that outran the idle pool
+        // all leave whatever they held bound and push the rest out in
+        // arrival order. `WorkerAllocator::rebind_surplus_by_priority`
+        // exists to correct exactly that — it moves workers off the
+        // worst-ranked bound allocations onto the best-ranked orphans —
+        // and its doc comment states the contract this function is
+        // meant to honour: "the surplus-leave path sheds them,
+        // lowest-scoring first — the same order used here, so the
+        // shards left unbound are the ones it will propose leaving."
+        //
+        // Shedding orphans first broke that contract, and it also raced
+        // ahead of the correction: a leave marks the allocation
+        // `Leaving`, and the rebind only promotes a *steady*
+        // `Active`/`Paused` orphan, so once shed it can never be
+        // reclaimed. The score-blind rule therefore always won.
+        //
+        // Observed on mainnet 2026-09-09: 27 allocations against 15
+        // workers; of the 14 shed, four were on the best-paying ring the
+        // node held while five bound allocations two rings down were
+        // kept, and the allocator logged `no_eligible_orphan: 12 unbound
+        // allocation(s), none steady Active/Paused` on every reconcile.
+        //
+        // Ties break toward the unbound allocation, so an equal-scoring
+        // running worker is never stopped for nothing.
+        //
+        // Exclusion set: manually-managed pins + any shard whose
+        // post-leave Active count would land at or below the halt-risk
+        // threshold (`active_count <= HALT_RISK_PROVER_COUNT + 1`,
+        // matching `plan_leaves` and `decide_leaves`). Shedding a shard
+        // already at the threshold OR one our departure would push into
+        // it would immediately worsen the network's exposure. Operators
+        // dealing with chronic capacity pressure should reduce worker
+        // count or add manual pins, not auto-shed halt-risk-adjacent
+        // shards.
+        //
+        // The shield protects coverage we are actually providing, so it
+        // covers bound allocations only. An allocation with no worker
+        // runs nothing: it counts towards the shard's Active total
+        // on-chain while contributing no proofs, so our departure costs
+        // the shard no coverage it was really getting — and holding it
+        // is not free either. Nothing encodes the replica or registers
+        // leaf roots for the epoch, so the FrameHeader possession audit
+        // evicts us from that shard anyway, and meanwhile the slot is
+        // kept from a prover who could staff it. Shielding an
+        // allocation we cannot staff protects a number, not a shard.
+        // This also matches the pre-ranking behaviour, where orphans
+        // bypassed the shield entirely. It does not make a halt-risk
+        // orphan likely to be shed: few provers means a low ring, which
+        // scores high, so the ranking keeps it anyway — and
+        // `priority_key` gives it the top rebind tier.
+        let mut excluded = mm_filters.clone();
+        for d in allocated_descriptors {
+            if d.size > 0
+                && d.active_count <= proposer::HALT_RISK_PROVER_COUNT + 1
+                && bound_filters.contains(&d.filter)
+            {
+                excluded.insert(d.filter.clone());
             }
         }
+        let mut ranked = proposer::rank_allocated_by_score_ascending(
+            allocated_descriptors,
+            difficulty,
+            world_bytes,
+            self.units,
+            self.strategy,
+            &excluded,
+        );
+        ranked.sort_by(|a, b| {
+            a.1.cmp(&b.1)
+                .then_with(|| bound_filters.contains(&a.0).cmp(&bound_filters.contains(&b.0)))
+        });
+        // A filter that's `Active` but absent from `allocated_descriptors`
+        // is, in practice, a size-0 shard (build_decide_descriptors
+        // skipped it). Mirroring Go's `worker_allocator.go:821-824` —
+        // where `if size == 0 { continue }` lands BEFORE
+        // `leaveProposalCandidates = append(...)` — we deliberately
+        // do NOT pick those here. The empty-allocated path in the
+        // main ProposeLeave block surfaces them.
+        let mut picks: Vec<Vec<u8>> =
+            ranked.into_iter().take(surplus).map(|(f, _)| f).collect();
         picks.truncate(MAX_PROPOSALS_PER_CYCLE);
         picks
     }
@@ -1219,7 +1249,49 @@ impl ProverLifecycle {
         // pending frame) and registry confirmation, the worker has an
         // empty filter but a non-zero pending frame.
         let free_worker_ids: Vec<u32> = worker_view.free_auto().map(|w| w.core_id).collect();
-        let allow_proposals = !free_worker_ids.is_empty();
+
+        // ...but "free" is a statement about the worker, not about the
+        // slot. `free_auto` reads worker state only, so it cannot see a
+        // slot already owed to an allocation we hold that nothing has
+        // bound yet. After a restart every worker starts with an empty
+        // filter while the registry still holds every allocation from
+        // before, and those filters are only installed when the
+        // allocator's reconcile next runs. A join cycle that clears its
+        // readiness gates first sees a fully idle fleet, proposes a
+        // second full set of joins on top of the set we already own,
+        // and the reconcile then has nowhere to put the surplus.
+        //
+        // Observed on mainnet 2026-09-09: the first cycle to clear the
+        // gates after a restart logged `free_workers=15
+        // total_workers=15` while the prover held 13 Active
+        // allocations, proposed a 14-filter join, and 14 seconds later
+        // the allocator reported `orphan_count=35`. Twelve of those
+        // allocations never received a worker and were shed at the next
+        // epoch boundary — four of them on the best-paying ring the
+        // node held.
+        //
+        // `JOIN_FILTER_COOLDOWN_FRAMES` does not cover this: it guards
+        // against the *same* filter being proposed by overlapping
+        // cycles, and here a single cycle proposed fourteen filters it
+        // had never proposed before.
+        //
+        // Leaving allocations are excluded — they are departing and
+        // will not claim a slot. Everything else in `all_ours` will.
+        let worker_bound_filters: std::collections::HashSet<Vec<u8>> =
+            worker_view.filter_set().map(|w| w.filter.clone()).collect();
+        let departing_filters: std::collections::HashSet<&Vec<u8>> =
+            leaving_filters.iter().map(|(f, _)| f).collect();
+        let unbound_held_count = all_our_filters
+            .iter()
+            .filter(|f| !departing_filters.contains(f))
+            .filter(|f| !worker_bound_filters.contains(*f))
+            .count();
+        let assignable_worker_ids: Vec<u32> = free_worker_ids
+            .iter()
+            .copied()
+            .take(free_worker_ids.len().saturating_sub(unbound_held_count))
+            .collect();
+        let allow_proposals = !assignable_worker_ids.is_empty();
 
         // Go's canPropose (cooldown + readiness + halt). The
         // readiness snapshot was captured at the top of evaluate;
@@ -1490,6 +1562,8 @@ impl ProverLifecycle {
             info!(
                 frame = frame_number,
                 free_workers = free_worker_ids.len(),
+                assignable_workers = assignable_worker_ids.len(),
+                unbound_held = unbound_held_count,
                 total_workers = workers.len(),
                 candidates = proposal_descriptors.len(),
                 halt_risk_among_candidates = proposal_halt_risk,
@@ -1530,7 +1604,7 @@ impl ProverLifecycle {
                     difficulty,
                     &world_bytes,
                     self.units,
-                    &free_worker_ids,
+                    &assignable_worker_ids,
                     MAX_PROPOSALS_PER_CYCLE,
                     self.strategy,
                 );
@@ -1742,7 +1816,9 @@ impl ProverLifecycle {
             // joins included, since `worker.filter` is set at submit
             // time before the alloc activates). An Active filter NOT
             // in this set is an orphan — the prover still owns the
-            // allocation but nothing is doing the work.
+            // allocation but nothing is doing the work. Used only to
+            // break score ties below; being an orphan is no longer by
+            // itself a reason to leave.
             let bound_filters: std::collections::HashSet<Vec<u8>> = workers
                 .iter()
                 .filter(|w| !w.filter.is_empty())
@@ -1761,12 +1837,10 @@ impl ProverLifecycle {
                 .cloned()
                 .collect();
 
-            // Orphan filters: on-chain Active allocations with no worker bound.
-            // Always propose leave regardless of shard score — there's
-            // no useful work to retain. Fixes the "extra allocation
-            // from earlier issues, shows as -1 in TUI" case where the
-            // allocation lingers on a healthy shard and plan_leaves /
-            // surplus-leave can't (or won't) pick it.
+            // Unrecoverable orphans: on-chain allocations with no worker
+            // bound that nothing can ever staff. Always propose leave
+            // regardless of shard score — there is no useful work to
+            // retain and no path back.
             //
             // ExpiredEpoch allocations MUST be candidates here, not just
             // `active` ones. Being orphaned is precisely what makes an
@@ -1783,13 +1857,114 @@ impl ProverLifecycle {
             // They stay OUT of `active` itself — that set is coverage
             // accounting, and an unconfirmed allocation genuinely does not
             // count. This only widens who may be shed.
-            let orphan_filters = orphaned_allocation_filters(
-                &active_filters,
+            //
+            // Ranking cannot rescue these, which is why they stay a
+            // score-blind sweep while Active orphans do not:
+            // `rebind_surplus_by_priority` promotes only a *steady*
+            // `Active`/`Paused` orphan, so an ExpiredEpoch one can
+            // neither be staffed nor score its way back into
+            // contention. Retaining a high-scoring one would rebuild
+            // the same deadlock this sweep exists to break. An Active
+            // orphan is recoverable, so it is ranked with everything
+            // else below instead of being shed on sight.
+            let unrecoverable_orphan_filters = orphaned_allocation_filters(
+                &[],
                 &expired_epoch_for_orphan_sweep,
                 &bound_filters,
                 &manually_managed_filters,
                 &pending_leave_filters,
             );
+            // Over-capacity filters: allocations this prover cannot
+            // staff, worst-scoring first.
+            //
+            // This used to be "every Active allocation with no worker
+            // bound, leave it regardless of score." But which
+            // allocations hold a worker is decided by bind order in the
+            // allocator, not by score — a worker lost to a crash, a
+            // reduced core count, or a join batch that outran the idle
+            // pool all leave whatever they held bound and push the rest
+            // out in arrival order. `rebind_surplus_by_priority` exists
+            // to correct exactly that: it moves workers off the
+            // worst-ranked bound allocations onto the best-ranked
+            // orphans. It only promotes an orphan that is still
+            // *steady* `Active`/`Paused`, so proposing Leave the moment
+            // an allocation is unbound marks it `Leaving` and makes it
+            // permanently ineligible — the score-blind rule wins the
+            // race against the score-aware one, and the shed set ends
+            // up decided by bind order after all.
+            //
+            // Observed on mainnet 2026-09-09: of 27 allocations against
+            // 15 workers, the 14 shed included four on the best ring
+            // the node held while five bound allocations two rings down
+            // were kept, and the allocator logged `no_eligible_orphan:
+            // 12 unbound allocation(s), none steady Active/Paused` on
+            // every reconcile for hours.
+            //
+            // So shed by rank instead: only the count we cannot staff,
+            // taken worst-scoring first across the whole held set,
+            // bound or not. That is the same ordering the rebind path
+            // uses, which restores the invariant its doc comment
+            // already claims — "the shards left unbound are the ones it
+            // will propose leaving." Ties break toward the unbound one
+            // so an equal-scoring running worker is not stopped for
+            // nothing. With no over-capacity nothing is shed: an orphan
+            // that fits within worker capacity gets a worker on the
+            // next reconcile, and leaving it would throw away a live
+            // allocation to fix a transient. That still covers the
+            // original "extra allocation lingers, shows as -1 in the
+            // TUI" case — with slack it is bound, without slack it is
+            // shed if it really is among the worst.
+            let sheddable_filters: Vec<Vec<u8>> = active_filters
+                .iter()
+                .filter(|f| !manually_managed_filters.contains(*f))
+                .filter(|f| !pending_leave_filters.contains(*f))
+                .cloned()
+                .collect();
+            // Capacity for auto-managed allocations is the worker count
+            // less the operator's pins, matching the set above.
+            let auto_worker_capacity = workers.iter().filter(|w| !w.manually_managed).count();
+            let overcapacity = sheddable_filters.len().saturating_sub(auto_worker_capacity);
+            let overcapacity_filters: Vec<Vec<u8>> = if overcapacity == 0 {
+                Vec::new()
+            } else {
+                let sheddable: std::collections::HashSet<&Vec<u8>> =
+                    sheddable_filters.iter().collect();
+                // Excluded from the ranking: anything not sheddable, and
+                // the halt-risk shield from `plan_leaves` — `active_count`
+                // includes us, so a shard at or below
+                // `HALT_RISK_PROVER_COUNT + 1` drops into halt risk the
+                // moment we go. As in `select_excess_active_filters`, the
+                // shield covers bound allocations only: an unbound one
+                // contributes no proofs, so our leaving costs the shard
+                // no coverage it was really getting, and holding it only
+                // waits for the possession audit to evict us.
+                let excluded: std::collections::HashSet<Vec<u8>> = allocated_descriptors
+                    .iter()
+                    .filter(|d| {
+                        !sheddable.contains(&d.filter)
+                            || (d.size > 0
+                                && d.active_count <= proposer::HALT_RISK_PROVER_COUNT + 1
+                                && bound_filters.contains(&d.filter))
+                    })
+                    .map(|d| d.filter.clone())
+                    .collect();
+                let mut ranked = proposer::rank_allocated_by_score_ascending(
+                    &allocated_descriptors,
+                    difficulty,
+                    &world_bytes,
+                    self.units,
+                    self.strategy,
+                    &excluded,
+                );
+                ranked.sort_by(|a, b| {
+                    a.1.cmp(&b.1).then_with(|| {
+                        bound_filters
+                            .contains(&a.0)
+                            .cmp(&bound_filters.contains(&b.0))
+                    })
+                });
+                ranked.into_iter().take(overcapacity).map(|(f, _)| f).collect()
+            };
 
             // §6.1 Option-A: SPLIT-PARENT filters — an Active filter that has been
             // SPLIT, i.e. some registered shard is a strict bit-path DESCENDANT of
@@ -1852,7 +2027,7 @@ impl ProverLifecycle {
                     &world_bytes,
                     self.units,
                     self.strategy,
-                    free_worker_ids.len(),
+                    assignable_worker_ids.len(),
                     &min_hold_filters,
                 )
             } else {
@@ -1867,20 +2042,32 @@ impl ProverLifecycle {
                 }
             }
             let empty_shard_count = leave_candidates.len() - score_driven_count;
-            for f in &orphan_filters {
+            for f in &unrecoverable_orphan_filters {
                 if !leave_candidates.contains(f) {
                     leave_candidates.push(f.clone());
                 }
             }
-            let orphan_count =
+            let unrecoverable_orphan_count =
                 leave_candidates.len() - score_driven_count - empty_shard_count;
+            for f in &overcapacity_filters {
+                if !leave_candidates.contains(f) {
+                    leave_candidates.push(f.clone());
+                }
+            }
+            let overcapacity_count = leave_candidates.len()
+                - score_driven_count
+                - empty_shard_count
+                - unrecoverable_orphan_count;
             for f in &split_parent_filters {
                 if !leave_candidates.contains(f) {
                     leave_candidates.push(f.clone());
                 }
             }
-            let split_parent_count =
-                leave_candidates.len() - score_driven_count - empty_shard_count - orphan_count;
+            let split_parent_count = leave_candidates.len()
+                - score_driven_count
+                - empty_shard_count
+                - unrecoverable_orphan_count
+                - overcapacity_count;
             if split_parent_count > 0 {
                 tracing::info!(
                     split_parent_count,
@@ -1925,10 +2112,12 @@ impl ProverLifecycle {
                     leave_proposals = leave_candidates.len(),
                     score_driven = score_driven_count,
                     empty_allocated = empty_shard_count,
-                    orphan = orphan_count,
+                    unrecoverable_orphans = unrecoverable_orphan_count,
+                    overcapacity = overcapacity_count,
+                    auto_worker_capacity,
                     cooldown_suppressed,
                     ?leave_summary,
-                    "proposing leaves (overcrowded + empty + orphan)"
+                    "proposing leaves (score-driven + empty + over-capacity)"
                 );
                 actions.push(LifecycleAction::ProposeLeave {
                     filters: leave_candidates,
@@ -3452,35 +3641,47 @@ mod proposal_loop_tests {
         );
     }
 
-    /// User report: "extra allocation from earlier issues, in the TUI
-    /// it shows as -1 for the worker id, never leaves successfully".
-    /// An active allocation whose filter is not bound to any worker is
-    /// an orphan. plan_leaves alone can't fix it because if the orphan's
-    /// shard scores at-or-above 67% of the best alternative, plan_leaves
-    /// emits nothing for it. The orphan path proposes leave
-    /// unconditionally for unbound active filters.
+    /// Over-capacity sheds by score, not by which allocation happens to
+    /// hold a worker.
+    ///
+    /// User report: "extra allocation from earlier issues, in the TUI it
+    /// shows as -1 for the worker id, never leaves successfully". The
+    /// original fix shed every unbound Active filter unconditionally.
+    /// That threw away value: bind order is decided by the allocator's
+    /// arrival order, so the orphan is just as likely to be the best
+    /// allocation the prover holds. Here 0xA3 is unbound *and* the
+    /// highest-scoring of the three, so the worst-scoring 0xA1 goes
+    /// instead and `rebind_surplus_by_priority` moves its worker onto
+    /// 0xA3.
     #[test]
-    fn orphan_active_filter_gets_leave_proposed() {
+    fn overcapacity_sheds_the_worst_scoring_not_the_unbound() {
         let address = vec![0xCDu8; 32];
         let wm = Arc::new(ConfigurableWorkerManager::new());
         let reg = Arc::new(ConfigurableRegistry::new());
 
-        // One worker bound to 0xA1. Filter 0xA2 is an orphan — the
-        // allocation exists but no worker is doing the work.
+        // Two workers for three allocations. 0xA3 is the orphan.
         wm.add(allocated_worker(1, filter_bytes(0xA1)));
+        wm.add(allocated_worker(2, filter_bytes(0xA2)));
 
         let allocs = vec![
             alloc(filter_bytes(0xA1), ProverStatus::Active, 10),
             alloc(filter_bytes(0xA2), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA3), ProverStatus::Active, 10),
         ];
         reg.set_prover(prover(address.clone(), allocs));
 
-        // Both allocated filters score similarly; no plan_leaves trigger.
-        // Unallocated alternatives present but not dominantly better.
+        // Same prover count on all three (so ring, and therefore the
+        // halt-risk shield, are identical) and score ordered purely by
+        // size: 0xA1 worst, 0xA3 best.
+        let sized = |filter: Vec<u8>, active: u32, size: u64| {
+            let mut counts: HashMap<ProverStatus, u32> = HashMap::new();
+            counts.insert(ProverStatus::Active, active);
+            ProverShardSummary { filter, status_counts: counts, total_size: size }
+        };
         reg.set_summaries(vec![
-            shard_summary(filter_bytes(0xA1), 1),
-            shard_summary(filter_bytes(0xA2), 1),
-            shard_summary(filter_bytes(0xB0), 1),
+            sized(filter_bytes(0xA1), 10, 1_000_000),
+            sized(filter_bytes(0xA2), 10, 5_000_000),
+            sized(filter_bytes(0xA3), 10, 9_000_000),
         ]);
 
         let lifecycle = make_lifecycle(
@@ -3500,13 +3701,178 @@ mod proposal_loop_tests {
             .flatten()
             .collect();
         assert!(
-            leave_filters.contains(&filter_bytes(0xA2)),
-            "expected ProposeLeave for orphan 0xA2 (no worker bound); got {:?}",
+            leave_filters.contains(&filter_bytes(0xA1)),
+            "expected ProposeLeave for the worst-scoring 0xA1; got {:?}",
             actions
         );
         assert!(
+            !leave_filters.contains(&filter_bytes(0xA3)),
+            "must NOT shed the best-scoring allocation just because it is \
+             unbound; got {:?}",
+            actions
+        );
+    }
+
+    /// Same shape, inverted: when the unbound allocation really is the
+    /// worst one, it is the one shed. Without this the test above would
+    /// pass for a rule that simply never sheds an orphan.
+    #[test]
+    fn overcapacity_sheds_the_unbound_when_it_is_the_worst() {
+        let address = vec![0xCDu8; 32];
+        let wm = Arc::new(ConfigurableWorkerManager::new());
+        let reg = Arc::new(ConfigurableRegistry::new());
+
+        wm.add(allocated_worker(1, filter_bytes(0xA1)));
+        wm.add(allocated_worker(2, filter_bytes(0xA2)));
+
+        let allocs = vec![
+            alloc(filter_bytes(0xA1), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA2), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA3), ProverStatus::Active, 10),
+        ];
+        reg.set_prover(prover(address.clone(), allocs));
+
+        let sized = |filter: Vec<u8>, active: u32, size: u64| {
+            let mut counts: HashMap<ProverStatus, u32> = HashMap::new();
+            counts.insert(ProverStatus::Active, active);
+            ProverShardSummary { filter, status_counts: counts, total_size: size }
+        };
+        reg.set_summaries(vec![
+            sized(filter_bytes(0xA1), 10, 9_000_000),
+            sized(filter_bytes(0xA2), 10, 5_000_000),
+            sized(filter_bytes(0xA3), 10, 1_000_000),
+        ]);
+
+        let lifecycle = make_lifecycle(
+            address,
+            wm.clone() as Arc<dyn WorkerManager>,
+            reg.clone() as Arc<dyn ProverRegistry>,
+        );
+        lifecycle.set_prover_root_verified_frame(100);
+
+        let actions = lifecycle.evaluate(100, 1, reg.as_ref(), wm.as_ref()).unwrap();
+        let leave_filters: Vec<Vec<u8>> = actions
+            .iter()
+            .filter_map(|a| match a {
+                LifecycleAction::ProposeLeave { filters, .. } => Some(filters.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert!(
+            leave_filters.contains(&filter_bytes(0xA3)),
+            "expected ProposeLeave for the worst-scoring (and unbound) 0xA3; \
+             got {:?}",
+            actions
+        );
+    }
+
+    /// An unbound allocation that fits inside worker capacity is a
+    /// transient — the allocator's next reconcile binds a worker to it.
+    /// Shedding it would throw away a live allocation to fix nothing.
+    #[test]
+    fn an_unbound_allocation_within_capacity_is_not_shed() {
+        let address = vec![0xCDu8; 32];
+        let wm = Arc::new(ConfigurableWorkerManager::new());
+        let reg = Arc::new(ConfigurableRegistry::new());
+
+        // Three workers, two allocations: 0xA2 is unbound but there is
+        // an idle worker waiting for it.
+        wm.add(allocated_worker(1, filter_bytes(0xA1)));
+        wm.add(idle_worker(2));
+        wm.add(idle_worker(3));
+
+        let allocs = vec![
+            alloc(filter_bytes(0xA1), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA2), ProverStatus::Active, 10),
+        ];
+        reg.set_prover(prover(address.clone(), allocs));
+
+        let sized = |filter: Vec<u8>, active: u32, size: u64| {
+            let mut counts: HashMap<ProverStatus, u32> = HashMap::new();
+            counts.insert(ProverStatus::Active, active);
+            ProverShardSummary { filter, status_counts: counts, total_size: size }
+        };
+        reg.set_summaries(vec![
+            sized(filter_bytes(0xA1), 10, 1_000_000),
+            sized(filter_bytes(0xA2), 10, 1_000_000),
+        ]);
+
+        let lifecycle = make_lifecycle(
+            address,
+            wm.clone() as Arc<dyn WorkerManager>,
+            reg.clone() as Arc<dyn ProverRegistry>,
+        );
+        lifecycle.set_prover_root_verified_frame(100);
+
+        let actions = lifecycle.evaluate(100, 1, reg.as_ref(), wm.as_ref()).unwrap();
+        assert_eq!(
+            count_proposed_leaves(&actions),
+            0,
+            "an orphan inside capacity must wait for a rebind, not be shed; \
+             got {:?}",
+            actions
+        );
+    }
+
+    /// The halt-risk shield covers coverage we actually provide, so it
+    /// applies to bound allocations only. 0xA1 is the worst-scoring
+    /// allocation the prover holds and sits on a halt-risk shard, but a
+    /// worker is running it, so it is protected; 0xA3 is on an equally
+    /// thin shard with no worker, contributes no proofs, and goes.
+    #[test]
+    fn halt_risk_shield_covers_bound_allocations_only() {
+        let address = vec![0xCDu8; 32];
+        let wm = Arc::new(ConfigurableWorkerManager::new());
+        let reg = Arc::new(ConfigurableRegistry::new());
+
+        wm.add(allocated_worker(1, filter_bytes(0xA1)));
+        wm.add(allocated_worker(2, filter_bytes(0xA2)));
+
+        let allocs = vec![
+            alloc(filter_bytes(0xA1), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA2), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA3), ProverStatus::Active, 10),
+        ];
+        reg.set_prover(prover(address.clone(), allocs));
+
+        let sized = |filter: Vec<u8>, active: u32, size: u64| {
+            let mut counts: HashMap<ProverStatus, u32> = HashMap::new();
+            counts.insert(ProverStatus::Active, active);
+            ProverShardSummary { filter, status_counts: counts, total_size: size }
+        };
+        reg.set_summaries(vec![
+            sized(filter_bytes(0xA1), 3, 1_000),
+            sized(filter_bytes(0xA2), 10, 50_000_000),
+            sized(filter_bytes(0xA3), 3, 1_000),
+        ]);
+
+        let lifecycle = make_lifecycle(
+            address,
+            wm.clone() as Arc<dyn WorkerManager>,
+            reg.clone() as Arc<dyn ProverRegistry>,
+        );
+        lifecycle.set_prover_root_verified_frame(100);
+
+        let actions = lifecycle.evaluate(100, 1, reg.as_ref(), wm.as_ref()).unwrap();
+        let leave_filters: Vec<Vec<u8>> = actions
+            .iter()
+            .filter_map(|a| match a {
+                LifecycleAction::ProposeLeave { filters, .. } => Some(filters.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert!(
             !leave_filters.contains(&filter_bytes(0xA1)),
-            "must NOT leave the worker-bound filter 0xA1; got {:?}",
+            "a bound allocation on a halt-risk shard keeps the shield even as \
+             the worst scorer; got {:?}",
+            actions
+        );
+        assert!(
+            leave_filters.contains(&filter_bytes(0xA3)),
+            "an unbound allocation on a halt-risk shard provides no coverage \
+             and is sheddable; got {:?}",
             actions
         );
     }
@@ -3633,6 +3999,110 @@ mod proposal_loop_tests {
         assert_eq!(
             proposed, 1,
             "expected at most 1 join (only 1 free worker); got {} in {:?}",
+            proposed, actions
+        );
+    }
+
+    /// A worker with an empty filter is not necessarily a free slot.
+    ///
+    /// After a restart every worker starts unbound while the registry
+    /// still holds every allocation from before; the allocator installs
+    /// the filters on its next reconcile. A join cycle that clears its
+    /// readiness gates first used to see a fully idle fleet and propose
+    /// a second full set of joins on top of the set already held.
+    ///
+    /// Mainnet 2026-09-09: `free_workers=15 total_workers=15` while
+    /// holding 13 Active allocations → a 14-filter join → 35 orphans 14
+    /// seconds later, 12 of which were shed at the next epoch boundary.
+    #[test]
+    fn join_budget_excludes_slots_owed_to_unbound_allocations() {
+        let address = vec![0xCDu8; 32];
+        let wm = Arc::new(ConfigurableWorkerManager::new());
+        let reg = Arc::new(ConfigurableRegistry::new());
+
+        // Post-restart shape: every worker idle, every allocation still
+        // held. Three slots, three allocations already owed them.
+        wm.add(idle_worker(1));
+        wm.add(idle_worker(2));
+        wm.add(idle_worker(3));
+
+        let allocs = vec![
+            alloc(filter_bytes(0xA1), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA2), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA3), ProverStatus::Active, 10),
+        ];
+        reg.set_prover(prover(address.clone(), allocs));
+
+        let mut summaries = vec![
+            shard_summary(filter_bytes(0xA1), 1),
+            shard_summary(filter_bytes(0xA2), 1),
+            shard_summary(filter_bytes(0xA3), 1),
+        ];
+        for i in 0..10u8 {
+            summaries.push(shard_summary(filter_bytes(0x10 + i), 1));
+        }
+        reg.set_summaries(summaries);
+
+        let lifecycle = make_lifecycle(
+            address,
+            wm.clone() as Arc<dyn WorkerManager>,
+            reg.clone() as Arc<dyn ProverRegistry>,
+        );
+        lifecycle.set_prover_root_verified_frame(100);
+
+        let actions = lifecycle.evaluate(100, 1, reg.as_ref(), wm.as_ref()).unwrap();
+        let proposed = count_proposed_joins(&actions);
+        assert_eq!(
+            proposed, 0,
+            "every idle worker is already owed to a held allocation, so the \
+             join budget is zero; got {} in {:?}",
+            proposed, actions
+        );
+    }
+
+    /// The control for the test above: the budget is a subtraction, not
+    /// a blanket "never join while an allocation is unbound." With two
+    /// slots more than allocations owed, exactly two joins go out.
+    #[test]
+    fn join_budget_is_free_workers_minus_unbound_allocations() {
+        let address = vec![0xCDu8; 32];
+        let wm = Arc::new(ConfigurableWorkerManager::new());
+        let reg = Arc::new(ConfigurableRegistry::new());
+
+        for core in 1..=5u32 {
+            wm.add(idle_worker(core));
+        }
+
+        let allocs = vec![
+            alloc(filter_bytes(0xA1), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA2), ProverStatus::Active, 10),
+            alloc(filter_bytes(0xA3), ProverStatus::Active, 10),
+        ];
+        reg.set_prover(prover(address.clone(), allocs));
+
+        let mut summaries = vec![
+            shard_summary(filter_bytes(0xA1), 1),
+            shard_summary(filter_bytes(0xA2), 1),
+            shard_summary(filter_bytes(0xA3), 1),
+        ];
+        for i in 0..10u8 {
+            summaries.push(shard_summary(filter_bytes(0x10 + i), 1));
+        }
+        reg.set_summaries(summaries);
+
+        let lifecycle = make_lifecycle(
+            address,
+            wm.clone() as Arc<dyn WorkerManager>,
+            reg.clone() as Arc<dyn ProverRegistry>,
+        );
+        lifecycle.set_prover_root_verified_frame(100);
+
+        let actions = lifecycle.evaluate(100, 1, reg.as_ref(), wm.as_ref()).unwrap();
+        let proposed = count_proposed_joins(&actions);
+        assert_eq!(
+            proposed, 2,
+            "5 idle workers less 3 allocations already owed a slot = 2; got \
+             {} in {:?}",
             proposed, actions
         );
     }


### PR DESCRIPTION
Both capacity paths shed unbound allocations first and score-blind. Which allocation holds a worker is set by bind order, not by value, so the shed set was too — and a leave marks it `Leaving`, which `rebind_surplus_by_priority` can no longer promote, since it takes only steady `Active`/`Paused`. Observed on mainnet: of 27 allocations against 15 workers, the 14 shed included the best-paying ring the node held while lower-scoring bound allocations were kept.

The join budget compounded it. `free_auto` reports unbound workers, not free slots: after a restart every worker is unbound while the registry still holds every prior allocation, so one cycle proposed 14 joins on top of 13 already held.

Rank the whole held set worst-scoring first and shed only the count that cannot be staffed. Halt-risk shield scoped to bound allocations, ties broken toward the unbound. Budget joins as free workers less the slots owed to unbound held allocations.

Stacks on #651 — same block in `provers/lifecycle.rs`, merges after.

Tests: `cargo test --locked -p quil-engine --lib`

**Base:** `4eaf1f79`
